### PR TITLE
Fix Layer Assigned as Ref. to CME

### DIFF
--- a/zigzag/classes/stages/SpatialMappingGeneratorStage.py
+++ b/zigzag/classes/stages/SpatialMappingGeneratorStage.py
@@ -5,6 +5,7 @@ from zigzag.classes.stages.Stage import Stage
 from zigzag.classes.stages.SpatialMappingConversionStage import (
     SpatialMappingConversionStage,
 )
+import copy
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +87,7 @@ class SpatialMappingGeneratorStage(Stage):
             spatial_mapping_conversion_stage = SpatialMappingConversionStage(
                 self.list_of_callables,
                 accelerator=self.accelerator,
-                layer=self.layer,
+                layer=copy.copy(self.layer),
                 **self.kwargs,
             )
             for cme, extra_info in spatial_mapping_conversion_stage.run():


### PR DESCRIPTION
Solve an issue where the Layer assigned to the CME is passed as reference to the CME. This leads to all CMEs having the same layer at the end of the zigzag stage. Issue [14](https://github.com/KULeuven-MICAS/zigzag/issues/14)

The fix proposed is to copy the layer assigned to the CME instead.