### PR TITLE
Add constrainted temporal mapping

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,5 +1,5 @@
 name: Code Formatting
-on: [push]
+on: [push, pull_request]
 
 jobs:
   code-formatting:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,6 @@
 name: Lint with Pylint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/python-test-typeguard.yml
+++ b/.github/workflows/python-test-typeguard.yml
@@ -1,5 +1,5 @@
 name: Python test typeguard
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test-typeguard:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,5 +1,5 @@
 name: Python test
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/zigzag/datatypes.py
+++ b/zigzag/datatypes.py
@@ -100,11 +100,16 @@ class Constants:
 
     MEM_OP_1 = MemoryOperand(AcceleratorValidator.MEM_OP_1_STR)
     MEM_OP_2 = MemoryOperand(AcceleratorValidator.MEM_OP_2_STR)
+    
+class UnknownUnrollFactor:
+    '''! Placeholder class for unknown unroll factors, denoted by * in the mapping file'''
+    pass
+    
 
 
 ###### Type aliases ######
 UnrollFactor: TypeAlias = int | float
-UnrollFactorInt: TypeAlias = int
+UnrollFactorInt: TypeAlias = int | UnknownUnrollFactor
 
 PrLoop: TypeAlias = dict[LayerDim, tuple[LayerDim, LayerDim]]
 LoopList: TypeAlias = list[LayerDim]

--- a/zigzag/datatypes.py
+++ b/zigzag/datatypes.py
@@ -100,11 +100,12 @@ class Constants:
 
     MEM_OP_1 = MemoryOperand(AcceleratorValidator.MEM_OP_1_STR)
     MEM_OP_2 = MemoryOperand(AcceleratorValidator.MEM_OP_2_STR)
-    
+
+
 class UnknownUnrollFactor:
-    '''! Placeholder class for unknown unroll factors, denoted by * in the mapping file'''
+    """! Placeholder class for unknown unroll factors, denoted by * in the mapping file"""
+
     pass
-    
 
 
 ###### Type aliases ######

--- a/zigzag/datatypes.py
+++ b/zigzag/datatypes.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABCMeta
-from typing import Any, TypeAlias
+from typing import Any, Literal, TypeAlias
 
 import numpy as np
 
@@ -100,15 +100,11 @@ class Constants:
 
     MEM_OP_1 = MemoryOperand(AcceleratorValidator.MEM_OP_1_STR)
     MEM_OP_2 = MemoryOperand(AcceleratorValidator.MEM_OP_2_STR)
-
-
-class UnknownUnrollFactor:
-    """! Placeholder class for unknown unroll factors, denoted by * in the mapping file"""
-
-    pass
+    UNKNOWN_DIM_OPERATOR = LayerDim("*")
 
 
 ###### Type aliases ######
+UnknownUnrollFactor: TypeAlias = Literal["*"]
 UnrollFactor: TypeAlias = int | float
 UnrollFactorInt: TypeAlias = int | UnknownUnrollFactor
 

--- a/zigzag/opt/loma/LomaEngine.py
+++ b/zigzag/opt/loma/LomaEngine.py
@@ -73,7 +73,7 @@ class LomaEngine:
 
         self.show_progress_bar = kwargs.get("loma_show_progress_bar", False)
 
-    def give_constraints(self, constraints: list[PermutationConstraint]) -> None:
+    def set_constraints(self, constraints: list[PermutationConstraint]) -> None:
         self.constraints = constraints
 
     def run(self) -> Generator[TemporalMapping, None, None]:

--- a/zigzag/opt/loma/LomaEngine.py
+++ b/zigzag/opt/loma/LomaEngine.py
@@ -16,7 +16,7 @@ from zigzag.opt.loma.MemoryAllocator import (
     MemoryHierarchyTooSmallException,
     MemoryTooSmallException,
 )
-from zigzag.opt.loma.multipermute import permutations
+from zigzag.opt.loma.multipermute import PermutationConstraint, StaticPositionsAndSizesConstraint, permutations
 from zigzag.workload.layer_node import LayerNode
 
 logger = logging.getLogger(__name__)
@@ -62,6 +62,7 @@ class LomaEngine:
         self.accelerator = accelerator
         self.layer = layer
         self.spatial_mapping = spatial_mapping
+        self.constraints = []
 
         # Extract the memory hierarchy from the accelerator
         # TODO: Take into account that data might be stored in lower level,
@@ -71,6 +72,10 @@ class LomaEngine:
         self.memory_hierarchy = accelerator.get_core(core_id).memory_hierarchy
 
         self.show_progress_bar = kwargs.get("loma_show_progress_bar", False)
+    
+    def give_constraints(self, constraints: list[PermutationConstraint]) -> None:
+        self.constraints = constraints
+        
 
     def run(self) -> Generator[TemporalMapping, None, None]:
         """! Runs the LomaEngine
@@ -85,7 +90,7 @@ class LomaEngine:
 
         yielded = False
         for ordering in self.ordering_generator():
-            allocator = MemoryAllocator(self.accelerator, self.layer, self.spatial_mapping, ordering)
+            allocator = MemoryAllocator(self.accelerator, self.layer, self.spatial_mapping, ordering) # type: ignore
             # using try catch here because in the depth-first mode the highest level might not be big enough
             try:
                 temporal_mapping = allocator.run()  # allocate this ordering to the memories
@@ -210,13 +215,63 @@ class LomaEngine:
             "Launching %s temporal loop order permutations.",
             f"{self.nb_permutations:,}",
         )
-
+        
+        
+    def reduce_static_fps(self):
+        static_sizes: list[tuple[LayerDim, int]] = []
+        for constr in self.constraints:
+            if isinstance(constr, StaticPositionsAndSizesConstraint):
+                static_sizes = list(constr.static_positions_and_sizes.values())
+        for static_size in static_sizes:
+            factor_list: dict[int, int] = factorint(static_size[1]) # type: ignore
+            for factor, multiplicity in factor_list.items(): # type: ignore
+                index = self.temporal_loop_pfs[static_size[0]].index(factor)
+                if self.temporal_loop_pf_counts[static_size[0]][index] >= multiplicity:
+                    self.temporal_loop_pf_counts[static_size[0]] = tuple(
+                        count - multiplicity if i == index else count for i, count in enumerate(self.temporal_loop_pf_counts[static_size[0]])) # type: ignore
+                    # Add the static size to the count sums
+                    if static_size[1] in self.temporal_loop_pfs[static_size[0]]:
+                        self.temporal_loop_pf_counts[static_size[0]] = tuple(
+                            count + 1 if i == index else count for i, count in enumerate(self.temporal_loop_pf_counts[static_size[0]]) # type: ignore
+                            )
+                    else: 
+                        self.temporal_loop_pfs[static_size[0]] += (static_size[1],)
+                        self.temporal_loop_pf_counts[static_size[0]] += (1,)
+                    self.temporal_loop_pf_count_sums[static_size[0]] -= (multiplicity - 1)
+        
+        lpfs: list[tuple[LayerDim, int]] = []
+        for layer_dim, loop in self.temporal_loop_pfs.items():
+            for pf, count in zip(loop, self.temporal_loop_pf_counts[layer_dim]):
+                lpfs += list(((layer_dim, pf),) * count)
+        self.lpfs = lpfs
+        
+    def find_smallest_non_static_pf(self, layer_dim: LayerDim) -> tuple[int,int]:
+        static_sizes: list[tuple[LayerDim, int]] = []
+        for constr in self.constraints:
+            if isinstance(constr, StaticPositionsAndSizesConstraint):
+                static_sizes = list(constr.static_positions_and_sizes.values())
+        static_sizes_list = [static_sizes[i][1] for i in range(len(static_sizes)) if static_sizes[i][0] == layer_dim]
+        smallvalue = 0
+        already_first = False
+        for i in range(len(self.temporal_loop_pfs[layer_dim])):
+            if self.temporal_loop_pfs[layer_dim][i] not in static_sizes_list or self.temporal_loop_pf_counts[layer_dim][i] > static_sizes_list.count(self.temporal_loop_pfs[layer_dim][i]):
+                if already_first:
+                    return (smallvalue, i)
+                elif self.temporal_loop_pf_counts[layer_dim][i] > static_sizes_list.count(self.temporal_loop_pfs[layer_dim][i]) + 1:
+                    return (i, i)
+                else:
+                    smallvalue = i
+                    already_first = True
+        return (smallvalue, len(self.temporal_loop_pfs[layer_dim]) - 1)
+            
+        
     def limit_lpfs(self) -> None:
         """! Function to limit the total number of loop prime factors present in this instance.
         This function scans the lpfs and while the number of lpfs is greater than self.lpf_limit it:
         - picks the loop dimension that has the most lpfs
         - merges the smallest two lpfs of that loop dimension (multiplying their values)
         """
+        self.reduce_static_fps()
         n_pf = sum(self.temporal_loop_pf_count_sums.values())
         if self.lpf_limit is None or n_pf <= self.lpf_limit:
             logger.debug("No lpf limiting performed for layer %s", self.layer)
@@ -229,13 +284,10 @@ class LomaEngine:
             # Get the multiplicity of these prime factors
             max_counts: list[int] = list(self.temporal_loop_pf_counts[max_ld])
 
-            if max_counts[0] == 1:  # multiplicity of smallest pf is 1
-                new_factor = max_pfs[0] * max_pfs[1]
-                max_counts[0] -= 1
-                max_counts[1] -= 1
-            else:  # multiplicity of smallest pf is > 1
-                new_factor = max_pfs[0] * max_pfs[0]
-                max_counts[0] -= 2
+            smallest_non_static = self.find_smallest_non_static_pf(max_ld)
+            new_factor = max_pfs[smallest_non_static[0]] * max_pfs[smallest_non_static[1]]
+            max_counts[smallest_non_static[0]] -= 1
+            max_counts[smallest_non_static[1]] -= 1
 
             if new_factor in max_pfs:  # possible if not first iteration of while loop
                 new_factor_idx = max_pfs.index(new_factor)
@@ -267,7 +319,9 @@ class LomaEngine:
 
         logger.debug("Limited layer %s to %i lpfs.", self.layer, len(self.lpfs))
         return
+    
+    
 
     def ordering_generator(self) -> Generator[list[tuple[LayerDim, int]], None, None]:
         """! Generator that yields all orderings of the temporal loops."""
-        return permutations(self.lpfs)  # type:ignore
+        return permutations(self.lpfs, self.constraints)  # type:ignore

--- a/zigzag/opt/loma/LomaEngine.py
+++ b/zigzag/opt/loma/LomaEngine.py
@@ -216,39 +216,37 @@ class LomaEngine:
         )
 
     def reduce_static_fps(self):
-        static_sizes: list[tuple[LayerDim, int]] = []
-     try:
-         static_sizes = next(
+        try:
+            static_sizes = next(
                 (
                     v.static_positions_and_sizes.values()
                     for v in self.constraints
                     if isinstance(v, StaticPositionsAndSizesConstraint)
                 )
             )
-     
-          for static_size in static_sizes:
-              factor_list: dict[int, int] = factorint(static_size[1])  # type: ignore
-              for factor, multiplicity in factor_list.items():  # type: ignore
-                  index = self.temporal_loop_pfs[static_size[0]].index(factor)
-                  if self.temporal_loop_pf_counts[static_size[0]][index] >= multiplicity:
-                      self.temporal_loop_pf_counts[static_size[0]] = tuple(
-                          count - multiplicity if i == index else count
-                          for i, count in enumerate(self.temporal_loop_pf_counts[static_size[0]])  # type: ignore
-                      )
-                      # Add the static size to the count sums
-                      if static_size[1] in self.temporal_loop_pfs[static_size[0]]:
-                          self.temporal_loop_pf_counts[static_size[0]] = tuple(
-                              count + 1 if i == index else count
-                              for i, count in enumerate(self.temporal_loop_pf_counts[static_size[0]])  # type: ignore
-                          )
-                      else:
-                          self.temporal_loop_pfs[static_size[0]] += (static_size[1],)
-                          self.temporal_loop_pf_counts[static_size[0]] += (1,)
-                      self.temporal_loop_pf_count_sums[static_size[0]] -= multiplicity - 1
-    except StopIteration:
-        # No static sizes
-        pass
-                      
+
+            for static_size in static_sizes:
+                factor_list: dict[int, int] = factorint(static_size[1])  # type: ignore
+                for factor, multiplicity in factor_list.items():  # type: ignore
+                    index = self.temporal_loop_pfs[static_size[0]].index(factor)
+                    if self.temporal_loop_pf_counts[static_size[0]][index] >= multiplicity:
+                        self.temporal_loop_pf_counts[static_size[0]] = tuple(
+                            count - multiplicity if i == index else count
+                            for i, count in enumerate(self.temporal_loop_pf_counts[static_size[0]])  # type: ignore
+                        )
+                        # Add the static size to the count sums
+                        if static_size[1] in self.temporal_loop_pfs[static_size[0]]:
+                            self.temporal_loop_pf_counts[static_size[0]] = tuple(
+                                count + 1 if i == index else count
+                                for i, count in enumerate(self.temporal_loop_pf_counts[static_size[0]])  # type: ignore
+                            )
+                        else:
+                            self.temporal_loop_pfs[static_size[0]] += (static_size[1],)
+                            self.temporal_loop_pf_counts[static_size[0]] += (1,)
+                        self.temporal_loop_pf_count_sums[static_size[0]] -= multiplicity - 1
+        except StopIteration:
+            # No static sizes
+            pass
 
         lpfs: list[tuple[LayerDim, int]] = []
         for layer_dim, loop in self.temporal_loop_pfs.items():

--- a/zigzag/opt/loma/multipermute.py
+++ b/zigzag/opt/loma/multipermute.py
@@ -58,7 +58,8 @@ class PermutationConstraint(ABC):
     """! An abstract class to represent a constraint on a permutation."""
 
     @abstractmethod
-    def is_valid(self, permutation: list[Any]) -> bool: ...
+    def is_valid(self, permutation: list[Any]) -> bool:
+        ...
 
 
 class StaticPositionsConstraint(PermutationConstraint):
@@ -99,7 +100,7 @@ def init(multiset: list[Any]):
 
 
 def visit(h: ListElement) -> list[Any]:
-    """! Converts our bespoke linked list to a python list. hi"""
+    """! Converts our bespoke linked list to a python list."""
     o = h
     this_list: list[Any] = []
     while o is not None:

--- a/zigzag/opt/loma/multipermute.py
+++ b/zigzag/opt/loma/multipermute.py
@@ -99,7 +99,7 @@ def init(multiset: list[Any]):
 
 
 def visit(h: ListElement) -> list[Any]:
-    """! Converts our bespoke linked list to a python list."""
+    """! Converts our bespoke linked list to a python list. hi"""
     o = h
     this_list: list[Any] = []
     while o is not None:

--- a/zigzag/opt/loma/multipermute.py
+++ b/zigzag/opt/loma/multipermute.py
@@ -34,7 +34,7 @@
 # of Variables by Prefix Shifts."  Aaron Williams, 2009
 
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Any
 
 from zigzag.datatypes import LayerDim
@@ -57,9 +57,8 @@ class ListElement:
 class PermutationConstraint(ABC):
     """! An abstract class to represent a constraint on a permutation."""
 
-    def is_valid(self, permutation: list[Any]) -> bool:
-        """! Returns True if the permutation satisfies the constraint."""
-        raise NotImplementedError
+    @abstractmethod
+    def is_valid(self, permutation: list[Any]) -> bool: ...
 
 
 class StaticPositionsConstraint(PermutationConstraint):
@@ -72,10 +71,7 @@ class StaticPositionsConstraint(PermutationConstraint):
         self.static_positions = static_positions
 
     def is_valid(self, permutation: list[Any]) -> bool:
-        for position, item in self.static_positions.items():
-            if permutation[position][0] != item:
-                return False
-        return True
+        return all(permutation[position][0] == item for position, item in self.static_positions.items())
 
 
 class StaticPositionsAndSizesConstraint(PermutationConstraint):
@@ -88,10 +84,10 @@ class StaticPositionsAndSizesConstraint(PermutationConstraint):
         self.static_positions_and_sizes = static_positions_and_sizes
 
     def is_valid(self, permutation: list[Any]) -> bool:
-        for position, (item, size) in self.static_positions_and_sizes.items():
-            if permutation[position][0] != item or permutation[position][1] != size:
-                return False
-        return True
+        return all(
+            permutation[position][0] == item and permutation[position][1] == size
+            for position, (item, size) in self.static_positions_and_sizes.items()
+        )
 
 
 def init(multiset: list[Any]):
@@ -129,5 +125,5 @@ def permutations(multiset: list[Any], constraints: list[PermutationConstraint]):
             i = t
         j = i.next_elem
         h = t
-        if all([constr.is_valid(visit(h)) for constr in constraints]):
+        if all(constr.is_valid(visit(h)) for constr in constraints):
             yield visit(h)

--- a/zigzag/opt/loma/multipermute.py
+++ b/zigzag/opt/loma/multipermute.py
@@ -112,7 +112,7 @@ def visit(h: ListElement) -> list[Any]:
 def permutations(multiset: list[Any], constraints: list[PermutationConstraint]):
     """! Generator providing all multiset permutations of a multiset."""
     h, i, j = init(multiset)
-    if all([constr.is_valid(visit(h)) for constr in constraints]):
+    if all(constr.is_valid(visit(h)) for constr in constraints):
         yield visit(h)
     while j.next_elem is not None or j.value < h.value:
         if j.next_elem is not None and i.value >= j.next_elem.value:

--- a/zigzag/opt/loma/multipermute.py
+++ b/zigzag/opt/loma/multipermute.py
@@ -52,6 +52,8 @@ class ListElement:
             o = o.next_elem
             i += 1
         return o
+
+
 class PermutationConstraint(ABC):
     """! An abstract class to represent a constraint on a permutation."""
 
@@ -61,7 +63,8 @@ class PermutationConstraint(ABC):
 
 
 class StaticPositionsConstraint(PermutationConstraint):
-    """! A class to represent a constraint on a permutation that requires a predefined order for some or all elements."""
+    """! A class to represent a constraint on a permutation that requires
+    a predefined order for some or all elements."""
 
     static_positions: dict[int, LayerDim]
 
@@ -74,8 +77,10 @@ class StaticPositionsConstraint(PermutationConstraint):
                 return False
         return True
 
+
 class StaticPositionsAndSizesConstraint(PermutationConstraint):
-    """! A class to represent a constraint on a permutation that requires a predefined order and size for some or all elements."""
+    """! A class to represent a constraint on a permutation
+    that requires a predefined order and size for some or all elements."""
 
     static_positions_and_sizes: dict[int, tuple[LayerDim, int]]
 
@@ -87,6 +92,7 @@ class StaticPositionsAndSizesConstraint(PermutationConstraint):
             if permutation[position][0] != item or permutation[position][1] != size:
                 return False
         return True
+
 
 def init(multiset: list[Any]):
     multiset.sort()  # ensures proper non-increasing order
@@ -124,4 +130,4 @@ def permutations(multiset: list[Any], constraints: list[PermutationConstraint]):
         j = i.next_elem
         h = t
         if all([constr.is_valid(visit(h)) for constr in constraints]):
-             yield visit(h)
+            yield visit(h)

--- a/zigzag/parser/MappingValidator.py
+++ b/zigzag/parser/MappingValidator.py
@@ -84,7 +84,7 @@ class MappingValidator:
             "type": "list",
             "schema": {
                 "type": "list",
-                "items": [{"type": "string"}, {"oneof":[{"type": "integer"}, {"type": "string","allowed": ["*"]}]}],
+                "items": [{"type": "string"}, {"oneof": [{"type": "integer"}, {"type": "string", "allowed": ["*"]}]}],
                 "minlength": 2,
                 "maxlength": 2,
             },

--- a/zigzag/parser/MappingValidator.py
+++ b/zigzag/parser/MappingValidator.py
@@ -84,7 +84,7 @@ class MappingValidator:
             "type": "list",
             "schema": {
                 "type": "list",
-                "items": [{"type": "string"}, {"type": "integer"}],
+                "items": [{"type": "string"}, {"oneof":[{"type": "integer"}, {"type": "string","allowed": ["*"]}]}],
                 "minlength": 2,
                 "maxlength": 2,
             },

--- a/zigzag/stages/WorkloadParserStage.py
+++ b/zigzag/stages/WorkloadParserStage.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from zigzag.datatypes import UnknownUnrollFactor
 from zigzag.parser.MappingValidator import MappingValidator
 from zigzag.parser.workload_factory import WorkloadFactory
 from zigzag.parser.WorkloadValidator import WorkloadValidator
@@ -60,6 +61,9 @@ class WorkloadParserStage(Stage):
         mapping_validator = MappingValidator(mapping_data)
         mapping_data = mapping_validator.normalized_data
         mapping_validate_success = mapping_validator.validate()
+        for temp_map in mapping_data[0]["temporal_ordering"]:
+            if temp_map[1] == "*":
+                temp_map[1] = UnknownUnrollFactor()
         if not mapping_validate_success:
             raise ValueError("Failed to validate user provided mapping.")
         return mapping_data

--- a/zigzag/stages/WorkloadParserStage.py
+++ b/zigzag/stages/WorkloadParserStage.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-from zigzag.datatypes import UnknownUnrollFactor
 from zigzag.parser.MappingValidator import MappingValidator
 from zigzag.parser.workload_factory import WorkloadFactory
 from zigzag.parser.WorkloadValidator import WorkloadValidator
@@ -61,9 +60,6 @@ class WorkloadParserStage(Stage):
         mapping_validator = MappingValidator(mapping_data)
         mapping_data = mapping_validator.normalized_data
         mapping_validate_success = mapping_validator.validate()
-        for temp_map in mapping_data[0]["temporal_ordering"]:
-            if temp_map[1] == "*":
-                temp_map[1] = UnknownUnrollFactor()
         if not mapping_validate_success:
             raise ValueError("Failed to validate user provided mapping.")
         return mapping_data

--- a/zigzag/stages/temporal_mapping_generator_stage.py
+++ b/zigzag/stages/temporal_mapping_generator_stage.py
@@ -59,7 +59,7 @@ class TemporalMappingGeneratorStage(Stage):
         all_temporal_loops = engine.get_temporal_loops()
         if provided_ordering.is_complete(all_temporal_loops):
             allocator = MemoryAllocator(
-                self.accelerator, self.layer, self.spatial_mapping, provided_ordering.to_legacy_format() # type: ignore
+                self.accelerator, self.layer, self.spatial_mapping, provided_ordering.to_legacy_format()  # type: ignore
             )
             temporal_mapping = allocator.run()
             yield temporal_mapping
@@ -71,5 +71,3 @@ class TemporalMappingGeneratorStage(Stage):
             # Generate from scratch
             for mapping in engine.run():
                 yield mapping
-        
-    

--- a/zigzag/stages/temporal_mapping_generator_stage.py
+++ b/zigzag/stages/temporal_mapping_generator_stage.py
@@ -66,7 +66,7 @@ class TemporalMappingGeneratorStage(Stage):
             return
         else:
             constraints: list[PermutationConstraint] = provided_ordering.get_constraints()
-            engine.give_constraints(constraints)
+            engine.set_constraints(constraints)
 
             # Generate from scratch
             for mapping in engine.run():

--- a/zigzag/workload/layer_attributes.py
+++ b/zigzag/workload/layer_attributes.py
@@ -194,7 +194,6 @@ class LayerTemporalOrdering(LayerAttribute):
          ['C',  3]]
         """
         self.data = [(LayerDim(str(loop[0])), int(loop[1]) if isinstance(loop[1], int) else None) for loop in data]
-        pass
 
     @staticmethod
     def empty():
@@ -236,7 +235,7 @@ class LayerTemporalOrdering(LayerAttribute):
         static_posistions_and_sizes_dict: dict[int, tuple[LayerDim, int]] = {}
         outer_loop = False
         for count, (layer_dim, factor) in enumerate(self.data):
-            if (layer_dim.name == "*") and (factor is None):
+            if (layer_dim == Constants.UNKNOWN_DIM_OPERATOR) and (factor is None):
                 outer_loop = True
             elif factor is None:
                 if not outer_loop:

--- a/zigzag/workload/layer_attributes.py
+++ b/zigzag/workload/layer_attributes.py
@@ -15,7 +15,11 @@ from zigzag.datatypes import (
     UnrollFactor,
     UnrollFactorInt,
 )
-from zigzag.opt.loma.multipermute import PermutationConstraint, StaticPositionsAndSizesConstraint, StaticPositionsConstraint
+from zigzag.opt.loma.multipermute import (
+    PermutationConstraint,
+    StaticPositionsAndSizesConstraint,
+    StaticPositionsConstraint,
+)
 from zigzag.workload.LayerAttribute import LayerAttribute
 
 logger = logging.getLogger(__name__)
@@ -191,7 +195,7 @@ class LayerTemporalOrdering(LayerAttribute):
         """
         self.data = [(LayerDim(str(loop[0])), int(loop[1]) if isinstance(loop[1], int) else None) for loop in data]
         pass
-    
+
     @staticmethod
     def empty():
         return LayerTemporalOrdering([])
@@ -226,13 +230,13 @@ class LayerTemporalOrdering(LayerAttribute):
 
     def to_legacy_format(self):
         return self.data
-    
+
     def get_constraints(self) -> list[PermutationConstraint]:
         static_posistions_dict: dict[int, LayerDim] = {}
         static_posistions_and_sizes_dict: dict[int, tuple[LayerDim, int]] = {}
         outer_loop = False
         for count, (layer_dim, factor) in enumerate(self.data):
-            if (layer_dim.name == '*') and (factor is None):
+            if (layer_dim.name == "*") and (factor is None):
                 outer_loop = True
             elif factor is None:
                 if not outer_loop:

--- a/zigzag/workload/layer_attributes.py
+++ b/zigzag/workload/layer_attributes.py
@@ -15,6 +15,7 @@ from zigzag.datatypes import (
     UnrollFactor,
     UnrollFactorInt,
 )
+from zigzag.opt.loma.multipermute import PermutationConstraint, StaticPositionsAndSizesConstraint, StaticPositionsConstraint
 from zigzag.workload.LayerAttribute import LayerAttribute
 
 logger = logging.getLogger(__name__)
@@ -188,8 +189,9 @@ class LayerTemporalOrdering(LayerAttribute):
         [['K', 12],
          ['C',  3]]
         """
-        self.data = [(LayerDim(str(loop[0])), int(loop[1])) for loop in data]
-
+        self.data = [(LayerDim(str(loop[0])), int(loop[1]) if isinstance(loop[1], int) else None) for loop in data]
+        pass
+    
     @staticmethod
     def empty():
         return LayerTemporalOrdering([])
@@ -201,7 +203,10 @@ class LayerTemporalOrdering(LayerAttribute):
         """Return wether this temporal ordering matches the given, mandatory loop sizes"""
         all_loops: defaultdict[LayerDim, UnrollFactor] = defaultdict(lambda: 1)
         for layer_dim, factor in self.data:
-            all_loops[layer_dim] *= factor
+            if not isinstance(factor, int):
+                return False
+            else:
+                all_loops[layer_dim] *= factor
 
         for layer_dim in all_loops:
             if all_loops[layer_dim] == 1:
@@ -221,6 +226,27 @@ class LayerTemporalOrdering(LayerAttribute):
 
     def to_legacy_format(self):
         return self.data
+    
+    def get_constraints(self) -> list[PermutationConstraint]:
+        static_posistions_dict: dict[int, LayerDim] = {}
+        static_posistions_and_sizes_dict: dict[int, tuple[LayerDim, int]] = {}
+        outer_loop = False
+        for count, (layer_dim, factor) in enumerate(self.data):
+            if (layer_dim.name == '*') and (factor is None):
+                outer_loop = True
+            elif factor is None:
+                if not outer_loop:
+                    static_posistions_dict[count] = layer_dim
+                else:
+                    static_posistions_dict[count - len(self.data)] = layer_dim
+            else:
+                if not outer_loop:
+                    static_posistions_and_sizes_dict[count] = (layer_dim, factor)
+                else:
+                    static_posistions_and_sizes_dict[count - len(self.data)] = (layer_dim, factor)
+        static_positions = StaticPositionsConstraint(static_posistions_dict)
+        static_posistions_and_sizes = StaticPositionsAndSizesConstraint(static_posistions_and_sizes_dict)
+        return [static_positions, static_posistions_and_sizes]
 
 
 class LayerPadding(LayerAttribute):


### PR DESCRIPTION
This pull request adds support for constrainted temporal mapping. This means that it is not necessary for the temporal mapping to be either fully defined in the mapping file, or not at all. By using constraints, some dimension positions or sizes can be given statically, while others can give freedom to the LomaEngine