### PR TITLE
Add test cases for constrained temporal mapping

### DIFF
--- a/tests/main/test_constrainted_mapping/test_ascend_like.py
+++ b/tests/main/test_constrainted_mapping/test_ascend_like.py
@@ -1,6 +1,5 @@
-import pytest
-
 from zigzag.api import get_hardware_performance_zigzag
+from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
 # Test case for when spatial_mapping is provided, while spatial_mapping_hint is not provided.
 
@@ -18,22 +17,25 @@ ens_lats = {
 }
 
 
-@pytest.fixture
+# @pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/ascend_like_constrainted.yaml"
 
 
-@pytest.fixture
+# @pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/ascend_like.yaml"
 
 
-@pytest.mark.parametrize("workload", workloads)
+# @pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
-    energy, latency, _ = get_hardware_performance_zigzag(
-        workload, accelerator, mapping, enable_mix_spatial_mapping=True
-    )
-    (expected_energy, expected_latency) = ens_lats[workload]
-    print(f"'{workload}': ({energy}, {latency}),")
-    assert energy == pytest.approx(expected_energy)  # type: ignore
-    assert latency == pytest.approx(expected_latency)  # type: ignore
+    energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
+    temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
+
+    for temp_mapping in temp_map_default:
+        if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
+            assert temp_mapping[-1][0].name == "OX"
+            assert temp_mapping[-2][0].name == "OY"
+
+
+test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_ascend_like.py
+++ b/tests/main/test_constrainted_mapping/test_ascend_like.py
@@ -1,0 +1,39 @@
+import pytest
+
+from zigzag.api import get_hardware_performance_zigzag
+
+# Test case for when spatial_mapping is provided, while spatial_mapping_hint is not provided.
+
+workloads = (
+    "zigzag/inputs/workload/resnet18.onnx",
+    "zigzag/inputs/workload/resnet18.yaml",
+)
+
+# Expected energy and latency for each workload defined above
+ens_lats = {
+    "zigzag/inputs/workload/alexnet.onnx": (5664863934, 8479644),
+    "zigzag/inputs/workload/mobilenetv2.onnx": (920740293, 3814440),
+    "zigzag/inputs/workload/resnet18.onnx": (1680938520, 3697986),
+    "zigzag/inputs/workload/resnet18.yaml": (2286320480, 4418088),
+}
+
+
+@pytest.fixture
+def mapping():
+    return "zigzag/inputs/mapping/ascend_like_constrainted.yaml"
+
+
+@pytest.fixture
+def accelerator():
+    return "zigzag/inputs/hardware/ascend_like.yaml"
+
+
+@pytest.mark.parametrize("workload", workloads)
+def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
+    energy, latency, _ = get_hardware_performance_zigzag(
+        workload, accelerator, mapping, enable_mix_spatial_mapping=True
+    )
+    (expected_energy, expected_latency) = ens_lats[workload]
+    print(f"'{workload}': ({energy}, {latency}),")
+    assert energy == pytest.approx(expected_energy)  # type: ignore
+    assert latency == pytest.approx(expected_latency)  # type: ignore

--- a/tests/main/test_constrainted_mapping/test_ascend_like.py
+++ b/tests/main/test_constrainted_mapping/test_ascend_like.py
@@ -1,3 +1,5 @@
+import pytest
+
 from zigzag.api import get_hardware_performance_zigzag
 from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
@@ -17,17 +19,17 @@ ens_lats = {
 }
 
 
-# @pytest.fixture
+@pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/ascend_like_constrainted.yaml"
 
 
-# @pytest.fixture
+@pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/ascend_like.yaml"
 
 
-# @pytest.mark.parametrize("workload", workloads)
+@pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
     energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
     temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
@@ -36,6 +38,3 @@ def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=
         if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
             assert temp_mapping[-1][0].name == "OX"
             assert temp_mapping[-2][0].name == "OY"
-
-
-test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_edge_tpu_like.py
+++ b/tests/main/test_constrainted_mapping/test_edge_tpu_like.py
@@ -1,6 +1,5 @@
-import pytest
-
 from zigzag.api import get_hardware_performance_zigzag
+from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
 # Test case for when both spatial_mapping and spatial_mapping_hint are provided.
 
@@ -18,22 +17,25 @@ ens_lats = {
 }
 
 
-@pytest.fixture
+# @pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml"
 
 
-@pytest.fixture
+# @pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/edge_tpu_like.yaml"
 
 
-@pytest.mark.parametrize("workload", workloads)
+# @pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
-    energy, latency, _ = get_hardware_performance_zigzag(
-        workload, accelerator, mapping, enable_mix_spatial_mapping=True
-    )
-    (expected_energy, expected_latency) = ens_lats[workload]
-    print(f"'{workload}': ({energy}, {latency}),")
-    assert energy == pytest.approx(expected_energy)  # type: ignore
-    assert latency == pytest.approx(expected_latency)  # type: ignore
+    energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
+    temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
+
+    for temp_mapping in temp_map_default:
+        if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
+            assert temp_mapping[-2][0].name == "OX"
+            assert temp_mapping[-1][0].name == "OY"
+
+
+test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_edge_tpu_like.py
+++ b/tests/main/test_constrainted_mapping/test_edge_tpu_like.py
@@ -1,3 +1,5 @@
+import pytest
+
 from zigzag.api import get_hardware_performance_zigzag
 from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
@@ -17,17 +19,17 @@ ens_lats = {
 }
 
 
-# @pytest.fixture
+@pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml"
 
 
-# @pytest.fixture
+@pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/edge_tpu_like.yaml"
 
 
-# @pytest.mark.parametrize("workload", workloads)
+@pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
     energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
     temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
@@ -36,6 +38,3 @@ def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=
         if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
             assert temp_mapping[-2][0].name == "OX"
             assert temp_mapping[-1][0].name == "OY"
-
-
-test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_edge_tpu_like.py
+++ b/tests/main/test_constrainted_mapping/test_edge_tpu_like.py
@@ -1,0 +1,39 @@
+import pytest
+
+from zigzag.api import get_hardware_performance_zigzag
+
+# Test case for when both spatial_mapping and spatial_mapping_hint are provided.
+
+workloads = (
+    "zigzag/inputs/workload/resnet18.onnx",
+    "zigzag/inputs/workload/resnet18.yaml",
+)
+
+# Expected energy and latency for each workload defined above
+ens_lats = {
+    "zigzag/inputs/workload/alexnet.onnx": (6159980160, 8337351),
+    "zigzag/inputs/workload/mobilenetv2.onnx": (742114179, 2421959),
+    "zigzag/inputs/workload/resnet18.onnx": (1735517944, 4055269),
+    "zigzag/inputs/workload/resnet18.yaml": (2029477205, 4738407),
+}
+
+
+@pytest.fixture
+def mapping():
+    return "zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml"
+
+
+@pytest.fixture
+def accelerator():
+    return "zigzag/inputs/hardware/edge_tpu_like.yaml"
+
+
+@pytest.mark.parametrize("workload", workloads)
+def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
+    energy, latency, _ = get_hardware_performance_zigzag(
+        workload, accelerator, mapping, enable_mix_spatial_mapping=True
+    )
+    (expected_energy, expected_latency) = ens_lats[workload]
+    print(f"'{workload}': ({energy}, {latency}),")
+    assert energy == pytest.approx(expected_energy)  # type: ignore
+    assert latency == pytest.approx(expected_latency)  # type: ignore

--- a/tests/main/test_constrainted_mapping/test_meta_prototype_like.py
+++ b/tests/main/test_constrainted_mapping/test_meta_prototype_like.py
@@ -1,0 +1,39 @@
+import pytest
+
+from zigzag.api import get_hardware_performance_zigzag
+
+# Test case for when an incomplete spatial_mapping is provided and spatial_mapping_hint is also provided.
+
+workloads = (
+    "zigzag/inputs/workload/resnet18.onnx",
+    "zigzag/inputs/workload/resnet18.yaml",
+)
+
+# Expected energy and latency for each workload defined above
+ens_lats = {
+    "zigzag/inputs/workload/alexnet.onnx": (5681909132.480001, 8279495.0),
+    "zigzag/inputs/workload/mobilenetv2.onnx": (909647916.68, 2602479.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1751779924.0000002, 3234867.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2259198622.68, 3884859.0),
+}
+
+
+@pytest.fixture
+def mapping():
+    return "zigzag/inputs/mapping/meta_prototype_like_constrainted.yaml"
+
+
+@pytest.fixture
+def accelerator():
+    return "zigzag/inputs/hardware/meta_prototype.yaml"
+
+
+@pytest.mark.parametrize("workload", workloads)
+def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
+    energy, latency, _ = get_hardware_performance_zigzag(
+        workload, accelerator, mapping, enable_mix_spatial_mapping=True
+    )
+    (expected_energy, expected_latency) = ens_lats[workload]
+    print(f"'{workload}': ({energy}, {latency}),")
+    assert energy == pytest.approx(expected_energy)  # type: ignore
+    assert latency == pytest.approx(expected_latency)  # type: ignore

--- a/tests/main/test_constrainted_mapping/test_meta_prototype_like.py
+++ b/tests/main/test_constrainted_mapping/test_meta_prototype_like.py
@@ -1,6 +1,5 @@
-import pytest
-
 from zigzag.api import get_hardware_performance_zigzag
+from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
 # Test case for when an incomplete spatial_mapping is provided and spatial_mapping_hint is also provided.
 
@@ -18,22 +17,25 @@ ens_lats = {
 }
 
 
-@pytest.fixture
+# @pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/meta_prototype_like_constrainted.yaml"
 
 
-@pytest.fixture
+# @pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/meta_prototype.yaml"
 
 
-@pytest.mark.parametrize("workload", workloads)
+# @pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
-    energy, latency, _ = get_hardware_performance_zigzag(
-        workload, accelerator, mapping, enable_mix_spatial_mapping=True
-    )
-    (expected_energy, expected_latency) = ens_lats[workload]
-    print(f"'{workload}': ({energy}, {latency}),")
-    assert energy == pytest.approx(expected_energy)  # type: ignore
-    assert latency == pytest.approx(expected_latency)  # type: ignore
+    energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
+    temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
+
+    for temp_mapping in temp_map_default:
+        if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
+            assert temp_mapping[-2][0].name == "OX"
+            assert temp_mapping[-1][0].name == "OY"
+
+
+test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_meta_prototype_like.py
+++ b/tests/main/test_constrainted_mapping/test_meta_prototype_like.py
@@ -1,3 +1,5 @@
+import pytest
+
 from zigzag.api import get_hardware_performance_zigzag
 from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
@@ -17,17 +19,17 @@ ens_lats = {
 }
 
 
-# @pytest.fixture
+@pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/meta_prototype_like_constrainted.yaml"
 
 
-# @pytest.fixture
+@pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/meta_prototype.yaml"
 
 
-# @pytest.mark.parametrize("workload", workloads)
+@pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
     energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
     temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
@@ -36,6 +38,3 @@ def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=
         if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
             assert temp_mapping[-2][0].name == "OX"
             assert temp_mapping[-1][0].name == "OY"
-
-
-test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_tesla_npu_like.py
+++ b/tests/main/test_constrainted_mapping/test_tesla_npu_like.py
@@ -1,6 +1,5 @@
-import pytest
-
 from zigzag.api import get_hardware_performance_zigzag
+from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
 # Test case for when only spatial_mapping_hint is provided.
 
@@ -18,22 +17,25 @@ ens_lats = {
 }
 
 
-@pytest.fixture
+# @pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml"
 
 
-@pytest.fixture
+# @pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/tesla_npu_like.yaml"
 
 
-@pytest.mark.parametrize("workload", workloads)
+# @pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
-    energy, latency, _ = get_hardware_performance_zigzag(
-        workload, accelerator, mapping, enable_mix_spatial_mapping=True
-    )
-    (expected_energy, expected_latency) = ens_lats[workload]
-    print(f"'{workload}': ({energy}, {latency}),")
-    assert energy == pytest.approx(expected_energy)  # type: ignore
-    assert latency == pytest.approx(expected_latency)  # type: ignore
+    energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
+    temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
+
+    for temp_mapping in temp_map_default:
+        if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
+            assert temp_mapping[-2][0].name == "OX"
+            assert temp_mapping[-1][0].name == "OY"
+
+
+test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_tesla_npu_like.py
+++ b/tests/main/test_constrainted_mapping/test_tesla_npu_like.py
@@ -1,3 +1,5 @@
+import pytest
+
 from zigzag.api import get_hardware_performance_zigzag
 from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
@@ -17,25 +19,21 @@ ens_lats = {
 }
 
 
-# @pytest.fixture
+@pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml"
 
 
-# @pytest.fixture
+@pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/tesla_npu_like.yaml"
 
 
-# @pytest.mark.parametrize("workload", workloads)
+@pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
     energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
     temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
 
     for temp_mapping in temp_map_default:
-        if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
-            assert temp_mapping[-2][0].name == "OX"
+        if "OY" in [dim[0].name for dim in temp_mapping]:
             assert temp_mapping[-1][0].name == "OY"
-
-
-test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_tesla_npu_like.py
+++ b/tests/main/test_constrainted_mapping/test_tesla_npu_like.py
@@ -1,0 +1,39 @@
+import pytest
+
+from zigzag.api import get_hardware_performance_zigzag
+
+# Test case for when only spatial_mapping_hint is provided.
+
+workloads = (
+    "zigzag/inputs/workload/resnet18.onnx",
+    "zigzag/inputs/workload/resnet18.yaml",
+)
+
+# Expected energy and latency for each workload defined above
+ens_lats = {
+    "zigzag/inputs/workload/alexnet.onnx": (6006136982.778, 8290892.0),
+    "zigzag/inputs/workload/mobilenetv2.onnx": (947736166.5380002, 1857838.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1604556365.552, 2828301.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2094141825.5040002, 3480232.0),
+}
+
+
+@pytest.fixture
+def mapping():
+    return "zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml"
+
+
+@pytest.fixture
+def accelerator():
+    return "zigzag/inputs/hardware/tesla_npu_like.yaml"
+
+
+@pytest.mark.parametrize("workload", workloads)
+def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621
+    energy, latency, _ = get_hardware_performance_zigzag(
+        workload, accelerator, mapping, enable_mix_spatial_mapping=True
+    )
+    (expected_energy, expected_latency) = ens_lats[workload]
+    print(f"'{workload}': ({energy}, {latency}),")
+    assert energy == pytest.approx(expected_energy)  # type: ignore
+    assert latency == pytest.approx(expected_latency)  # type: ignore

--- a/tests/main/test_constrainted_mapping/test_tpu_like.py
+++ b/tests/main/test_constrainted_mapping/test_tpu_like.py
@@ -1,6 +1,5 @@
-import pytest
-
 from zigzag.api import get_hardware_performance_zigzag
+from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
 # Test case for when more non-existent dimensions are provided in spatial_mapping_hint.
 
@@ -18,22 +17,25 @@ ens_lats = {
 }
 
 
-@pytest.fixture
+# @pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/tpu_like_constrainted.yaml"
 
 
-@pytest.fixture
+# @pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/tpu_like.yaml"
 
 
-@pytest.mark.parametrize("workload", workloads)
+# @pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621  # pylint: disable=W0621
-    energy, latency, _ = get_hardware_performance_zigzag(
-        workload, accelerator, mapping, enable_mix_spatial_mapping=True
-    )
-    (expected_energy, expected_latency) = ens_lats[workload]
-    print(f"'{workload}': ({energy}, {latency}),")
-    assert energy == pytest.approx(expected_energy)  # type: ignore
-    assert latency == pytest.approx(expected_latency)  # type: ignore
+    energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
+    temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]
+
+    for temp_mapping in temp_map_default:
+        if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
+            assert temp_mapping[-2][0].name == "OX"
+            assert temp_mapping[-1][0].name == "OY"
+
+
+test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_tpu_like.py
+++ b/tests/main/test_constrainted_mapping/test_tpu_like.py
@@ -1,3 +1,5 @@
+import pytest
+
 from zigzag.api import get_hardware_performance_zigzag
 from zigzag.visualization.results.print_mapping import get_temporal_spatial_loops
 
@@ -17,17 +19,17 @@ ens_lats = {
 }
 
 
-# @pytest.fixture
+@pytest.fixture
 def mapping():
     return "zigzag/inputs/mapping/tpu_like_constrainted.yaml"
 
 
-# @pytest.fixture
+@pytest.fixture
 def accelerator():
     return "zigzag/inputs/hardware/tpu_like.yaml"
 
 
-# @pytest.mark.parametrize("workload", workloads)
+@pytest.mark.parametrize("workload", workloads)
 def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621  # pylint: disable=W0621
     energy, latency, cmes = get_hardware_performance_zigzag(workload, accelerator, mapping)
     temp_map_default = [get_temporal_spatial_loops(cme[0])[0] for cme in cmes[0][1]]

--- a/tests/main/test_constrainted_mapping/test_tpu_like.py
+++ b/tests/main/test_constrainted_mapping/test_tpu_like.py
@@ -38,6 +38,3 @@ def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=
         if ("OX" in [dim[0].name for dim in temp_mapping]) and ("OY" in [dim[0].name for dim in temp_mapping]):
             assert temp_mapping[-2][0].name == "OX"
             assert temp_mapping[-1][0].name == "OY"
-
-
-test_api(workload=workloads[0], accelerator=accelerator(), mapping=mapping())

--- a/tests/main/test_constrainted_mapping/test_tpu_like.py
+++ b/tests/main/test_constrainted_mapping/test_tpu_like.py
@@ -1,0 +1,39 @@
+import pytest
+
+from zigzag.api import get_hardware_performance_zigzag
+
+# Test case for when more non-existent dimensions are provided in spatial_mapping_hint.
+
+workloads = (
+    "zigzag/inputs/workload/resnet18.onnx",
+    "zigzag/inputs/workload/resnet18.yaml",
+)
+
+# Expected energy and latency for each workload defined above
+ens_lats = {
+    "zigzag/inputs/workload/alexnet.onnx": (5589583403, 8671208),
+    "zigzag/inputs/workload/mobilenetv2.onnx": (932571650, 7304307),
+    "zigzag/inputs/workload/resnet18.onnx": (1759424218.3160002, 4495469.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2191903732.78, 4845353.0),
+}
+
+
+@pytest.fixture
+def mapping():
+    return "zigzag/inputs/mapping/tpu_like_constrainted.yaml"
+
+
+@pytest.fixture
+def accelerator():
+    return "zigzag/inputs/hardware/tpu_like.yaml"
+
+
+@pytest.mark.parametrize("workload", workloads)
+def test_api(workload: str, accelerator: str, mapping: str):  # pylint: disable=W0621  # pylint: disable=W0621
+    energy, latency, _ = get_hardware_performance_zigzag(
+        workload, accelerator, mapping, enable_mix_spatial_mapping=True
+    )
+    (expected_energy, expected_latency) = ens_lats[workload]
+    print(f"'{workload}': ({energy}, {latency}),")
+    assert energy == pytest.approx(expected_energy)  # type: ignore
+    assert latency == pytest.approx(expected_latency)  # type: ignore

--- a/zigzag/inputs/mapping/ascend_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/ascend_like_constrainted.yaml
@@ -11,8 +11,8 @@
       - OY, 2
   temporal_ordering:
     - ['*','*']
-    - [G, '*']
-    - [OY, 8]
+    - [K, 8]
+    - [OY, '*']
     - [OX, '*']
   memory_operand_links:
     O: O
@@ -32,8 +32,8 @@
       - OY, 1
   temporal_ordering:
     - ['*','*']
-    - [G, '*']
-    - [OY, 8]
+    - [G, 8]
+    - [OY, '*']
     - [OX, '*']
   memory_operand_links:
     O: O

--- a/zigzag/inputs/mapping/ascend_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/ascend_like_constrainted.yaml
@@ -1,0 +1,41 @@
+- name: default
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - K, 16
+    D2:
+      - C, 16
+    D3:
+      - OX, 2
+    D4:
+      - OY, 2
+  temporal_ordering:
+    - ['*','*']
+    - [G, '*']
+    - [OY, 8]
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Add
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 16
+    D2:
+      - C, 1
+    D3:
+      - OX, 1
+    D4:
+      - OY, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, '*']
+    - [OY, 8]
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1

--- a/zigzag/inputs/mapping/ascend_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/ascend_like_constrainted.yaml
@@ -10,10 +10,9 @@
     D4:
       - OY, 2
   temporal_ordering:
-    - ['*','*']
-    - [K, 8]
-    - [OY, '*']
     - [OX, '*']
+    - [OY, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2
@@ -31,10 +30,9 @@
     D4:
       - OY, 1
   temporal_ordering:
-    - ['*','*']
-    - [G, 8]
-    - [OY, '*']
     - [OX, '*']
+    - [OY, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/mapping/default_constrainted.yaml
+++ b/zigzag/inputs/mapping/default_constrainted.yaml
@@ -6,9 +6,9 @@
     D2:
       - C, 32
   temporal_ordering:
+    - [OX, '*']
+    - [OY, '*']
     - ['*','*']
-    - [K, '*']
-    - [C, '*']
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/mapping/default_constrainted.yaml
+++ b/zigzag/inputs/mapping/default_constrainted.yaml
@@ -1,0 +1,15 @@
+- name: default
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - K, 32
+    D2:
+      - C, 32
+  temporal_ordering:
+    - ['*','*']
+    - [K, '*']
+    - [C, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1

--- a/zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml
@@ -1,0 +1,62 @@
+- name: default
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - K, 8
+    D2:
+      - C, 8
+    D3:
+      - OX, 4
+    D4:
+      - OY, 4
+  temporal_ordering:
+    - ['*','*']
+    - [G, '*']
+    - [OY, 8]
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Add
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 8
+    D2:
+      - C, 1
+    D3:
+      - OX, 1
+    D4:
+      - OY, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, '*']
+    - [OY, 8]
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Pooling
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 8
+    D2:
+      - C, 1
+    D3:
+      - OX, 1
+    D4:
+      - OY, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, '*']
+    - [OY, 8]
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1

--- a/zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml
@@ -11,8 +11,8 @@
       - OY, 4
   temporal_ordering:
     - ['*','*']
-    - [G, '*']
-    - [OY, 8]
+    - [K, '*']
+    - [OY, 2]
     - [OX, '*']
   memory_operand_links:
     O: O
@@ -32,8 +32,8 @@
       - OY, 1
   temporal_ordering:
     - ['*','*']
-    - [G, '*']
-    - [OY, 8]
+    - [G, 8]
+    - [OY, '*']
     - [OX, '*']
   memory_operand_links:
     O: O
@@ -53,8 +53,8 @@
       - OY, 1
   temporal_ordering:
     - ['*','*']
-    - [G, '*']
-    - [OY, 8]
+    - [G, 8]
+    - [OY, '*']
     - [OX, '*']
   memory_operand_links:
     O: O

--- a/zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/edge_tpu_like_constrainted.yaml
@@ -10,10 +10,9 @@
     D4:
       - OY, 4
   temporal_ordering:
-    - ['*','*']
-    - [K, '*']
-    - [OY, 2]
+    - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2
@@ -31,10 +30,9 @@
     D4:
       - OY, 1
   temporal_ordering:
-    - ['*','*']
-    - [G, 8]
     - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2
@@ -52,10 +50,9 @@
     D4:
       - OY, 1
   temporal_ordering:
-    - ['*','*']
-    - [G, 8]
     - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/mapping/meta_prototype_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/meta_prototype_like_constrainted.yaml
@@ -1,0 +1,41 @@
+- name: default
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - K, 32
+    D2:
+      - C, 2
+    D3:
+      - OX, 4
+    D4:
+      - OY, 4
+  temporal_ordering:
+    - ['*','*']
+    - [G, 8]
+    - [OY, '*']
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Add
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 32
+    D2:
+      - C, 1
+    D3:
+      - OX, 1
+    D4:
+      - OY, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, 8]
+    - [OY, '*']
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1

--- a/zigzag/inputs/mapping/meta_prototype_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/meta_prototype_like_constrainted.yaml
@@ -10,10 +10,9 @@
     D4:
       - OY, 4
   temporal_ordering:
-    - ['*','*']
-    - [G, 8]
     - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2
@@ -31,10 +30,9 @@
     D4:
       - OY, 1
   temporal_ordering:
-    - ['*','*']
-    - [G, 8]
     - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml
@@ -9,7 +9,6 @@
       - OY, 4
   temporal_ordering:
     - [OY, '*']
-    - [OX, '*']
     - ['*','*']
   memory_operand_links:
     O: O
@@ -27,7 +26,6 @@
       - OY, 1
   temporal_ordering:
     - [OY, '*']
-    - [OX, '*']
     - ['*','*']
   memory_operand_links:
     O: O
@@ -45,7 +43,6 @@
       - OY, 1
   temporal_ordering:
     - [OY, '*']
-    - [OX, '*']
     - ['*','*']
   memory_operand_links:
     O: O

--- a/zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml
@@ -1,0 +1,56 @@
+- name: default
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - K, 32
+    D2:
+      - OX, 8
+    D3:
+      - OY, 4
+  temporal_ordering:
+    - ['*','*']
+    - [K, 8]
+    - [OY, '*']
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Add
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 32
+    D2:
+      - OX, 1
+    D3:
+      - OY, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, 8]
+    - [OY, '*']
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Pooling
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 32
+    D2:
+      - OX, 1
+    D3:
+      - OY, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, 8]
+    - [OY, '*']
+    - [OX, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1

--- a/zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/tesla_npu_like_constrainted.yaml
@@ -8,10 +8,9 @@
     D3:
       - OY, 4
   temporal_ordering:
-    - ['*','*']
-    - [K, 8]
     - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2
@@ -27,10 +26,9 @@
     D3:
       - OY, 1
   temporal_ordering:
-    - ['*','*']
-    - [G, 8]
     - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2
@@ -46,10 +44,9 @@
     D3:
       - OY, 1
   temporal_ordering:
-    - ['*','*']
-    - [G, 8]
     - [OY, '*']
     - [OX, '*']
+    - ['*','*']
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/mapping/tpu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/tpu_like_constrainted.yaml
@@ -6,9 +6,9 @@
     D2:
       - C, 32
   temporal_ordering:
+    - [OY, '*']
+    - [OX, '*']
     - ['*','*']
-    - [K, '*']
-    - [C, '*']
   memory_operand_links:
     O: O
     W: I2
@@ -22,9 +22,9 @@
     D2:
       - C, 1
   temporal_ordering:
+    - [OY, '*']
+    - [OX, '*']
     - ['*','*']
-    - [G, '*']
-    - [C, '*']
   memory_operand_links:
     O: O
     W: I2
@@ -38,9 +38,9 @@
     D2:
       - C, 1
   temporal_ordering:
+    - [OY, '*']
+    - [OX, '*']
     - ['*','*']
-    - [G, '*']
-    - [C, '*']
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/mapping/tpu_like_constrainted.yaml
+++ b/zigzag/inputs/mapping/tpu_like_constrainted.yaml
@@ -1,0 +1,65 @@
+- name: default
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - K, 32
+    D2:
+      - C, 32
+  temporal_ordering:
+    - ['*','*']
+    - [K, '*']
+    - [C, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Add
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 32
+    D2:
+      - C, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, '*']
+    - [C, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: Pooling
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - G, 32
+    D2:
+      - C, 1
+  temporal_ordering:
+    - ['*','*']
+    - [G, '*']
+    - [C, '*']
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1
+
+- name: example_name_of_layer0
+  core_allocation: [1]
+  spatial_mapping:
+    D1:
+      - C, 32
+    D2:
+      - K, 32
+  temporal_ordering:
+    - [OX, 112] # Innermost loop
+    - [OY, 112]
+    - [FX, 7]
+    - [FY, 7]
+    - [K, 2] # Outermost loop
+  memory_operand_links:
+    O: O
+    W: I2
+    I: I1


### PR DESCRIPTION
Add testcases where temporal mappings are used which make use of wild cards. this tests the new feature where only parts of the temporal mappings can be specified, and the other parts will be filled in by the LOMA engine