### PR TITLE
Replace Python hash which depends on seed with static sha512

### DIFF
--- a/zigzag/cost_model/cost_model.py
+++ b/zigzag/cost_model/cost_model.py
@@ -309,7 +309,6 @@ class CostModelEvaluation(CostModelEvaluationABC):
         self.access_same_data_considered_as_no_access = access_same_data_considered_as_no_access
 
         self.core_id = layer.core_allocation[0]
-        self.core_id = layer.core_allocation[0]
         core = accelerator.get_core(self.core_id)
         self.mem_level_list = core.memory_hierarchy.mem_level_list
         self.mem_hierarchy_dict = core.mem_hierarchy_dict

--- a/zigzag/cost_model/port_activity.py
+++ b/zigzag/cost_model/port_activity.py
@@ -1,6 +1,6 @@
 from zigzag.datatypes import LayerOperand
 from zigzag.hardware.architecture.memory_port import DataDirection
-
+from zigzag.utils import hash_sha512
 
 class PortActivity:
     """!  Class that collects all the data transfer rate (periodic) information for each DTL (data transfer link)."""
@@ -51,7 +51,7 @@ class PortActivity:
         return str(self.served_op_lv_dir)
 
     def __hash__(self):
-        return hash(self.served_op_lv_dir)
+        return hash_sha512(self.served_op_lv_dir)
 
 
 class PortBeginOrEndActivity:

--- a/zigzag/cost_model/port_activity.py
+++ b/zigzag/cost_model/port_activity.py
@@ -2,6 +2,7 @@ from zigzag.datatypes import LayerOperand
 from zigzag.hardware.architecture.memory_port import DataDirection
 from zigzag.utils import hash_sha512
 
+
 class PortActivity:
     """!  Class that collects all the data transfer rate (periodic) information for each DTL (data transfer link)."""
 

--- a/zigzag/datatypes.py
+++ b/zigzag/datatypes.py
@@ -7,6 +7,7 @@ import numpy as np
 from zigzag.parser.accelerator_validator import AcceleratorValidator
 from zigzag.utils import hash_sha512
 
+
 class OperandABC(metaclass=ABCMeta):
     """! Abstract Base Class for all dimension- and operand-like classes"""
 

--- a/zigzag/datatypes.py
+++ b/zigzag/datatypes.py
@@ -5,14 +5,14 @@ from typing import Any, Literal, TypeAlias
 import numpy as np
 
 from zigzag.parser.accelerator_validator import AcceleratorValidator
-
+from zigzag.utils import hash_sha512
 
 class OperandABC(metaclass=ABCMeta):
     """! Abstract Base Class for all dimension- and operand-like classes"""
 
     def __init__(self, name: str):
         self.__name = name
-        self.__hash = hash(name) ^ hash(type(self))
+        self.__hash = hash_sha512(name) ^ hash_sha512(type(self))
 
     @property
     def name(self):

--- a/zigzag/hardware/architecture/core.py
+++ b/zigzag/hardware/architecture/core.py
@@ -130,3 +130,10 @@ class Core:
             and self.operational_array == other.operational_array
             and self.memory_hierarchy == other.memory_hierarchy
         )
+
+    def has_same_performance(self, other: object) -> bool:
+        return (
+            isinstance(other, Core)
+            and self.operational_array == other.operational_array
+            and self.memory_hierarchy == other.memory_hierarchy
+        )

--- a/zigzag/hardware/architecture/core.py
+++ b/zigzag/hardware/architecture/core.py
@@ -4,7 +4,7 @@ from zigzag.hardware.architecture.memory_instance import MemoryInstance
 from zigzag.hardware.architecture.memory_level import MemoryLevel
 from zigzag.hardware.architecture.operational_array import OperationalArrayABC
 from zigzag.mapping.spatial_mapping import SpatialMapping
-from zigzag.utils import hash_sha512, json_repr_handler
+from zigzag.utils import json_repr_handler
 
 
 class Core:

--- a/zigzag/hardware/architecture/core.py
+++ b/zigzag/hardware/architecture/core.py
@@ -121,7 +121,7 @@ class Core:
         return json_repr_handler(self.__dict__)
 
     def __hash__(self) -> int:
-        return hash_sha512(self.id)
+        return self.id
 
     def __eq__(self, other: object) -> bool:
         return (

--- a/zigzag/hardware/architecture/core.py
+++ b/zigzag/hardware/architecture/core.py
@@ -4,7 +4,7 @@ from zigzag.hardware.architecture.memory_instance import MemoryInstance
 from zigzag.hardware.architecture.memory_level import MemoryLevel
 from zigzag.hardware.architecture.operational_array import OperationalArrayABC
 from zigzag.mapping.spatial_mapping import SpatialMapping
-from zigzag.utils import json_repr_handler
+from zigzag.utils import hash_sha512, json_repr_handler
 
 
 class Core:
@@ -121,7 +121,7 @@ class Core:
         return json_repr_handler(self.__dict__)
 
     def __hash__(self) -> int:
-        return hash(self.id)
+        return hash_sha512(self.id)
 
     def __eq__(self, other: object) -> bool:
         return (

--- a/zigzag/hardware/architecture/memory_level.py
+++ b/zigzag/hardware/architecture/memory_level.py
@@ -11,6 +11,7 @@ from zigzag.hardware.architecture.memory_port import (
 from zigzag.hardware.architecture.operational_array import OperationalArrayABC
 from zigzag.utils import hash_sha512
 
+
 class ServedMemDimensions:
     """! Represents a collection of Operational Array Dimensions (served by some Memory Instance)"""
 

--- a/zigzag/hardware/architecture/memory_level.py
+++ b/zigzag/hardware/architecture/memory_level.py
@@ -9,7 +9,7 @@ from zigzag.hardware.architecture.memory_port import (
     PortAllocation,
 )
 from zigzag.hardware.architecture.operational_array import OperationalArrayABC
-
+from zigzag.utils import hash_sha512
 
 class ServedMemDimensions:
     """! Represents a collection of Operational Array Dimensions (served by some Memory Instance)"""
@@ -163,4 +163,4 @@ class MemoryLevel:
         )
 
     def __hash__(self) -> int:
-        return hash(self.id)
+        return hash_sha512(self.id)

--- a/zigzag/mapping/spatial_mapping.py
+++ b/zigzag/mapping/spatial_mapping.py
@@ -4,9 +4,8 @@ import math
 from typing import Any
 
 from zigzag.datatypes import LayerDim, OADimension, UnrollFactor, UnrollFactorInt
-from zigzag.utils import UniqueMessageFilter, json_repr_handler
+from zigzag.utils import UniqueMessageFilter, hash_sha512, json_repr_handler
 from zigzag.workload.layer_attribute import LayerAttribute
-from zigzag.utils import hash_sha512
 
 logger = logging.getLogger(__name__)
 logger.addFilter(UniqueMessageFilter())

--- a/zigzag/mapping/spatial_mapping.py
+++ b/zigzag/mapping/spatial_mapping.py
@@ -6,6 +6,7 @@ from typing import Any
 from zigzag.datatypes import LayerDim, OADimension, UnrollFactor, UnrollFactorInt
 from zigzag.utils import UniqueMessageFilter, json_repr_handler
 from zigzag.workload.layer_attribute import LayerAttribute
+from zigzag.utils import hash_sha512
 
 logger = logging.getLogger(__name__)
 logger.addFilter(UniqueMessageFilter())
@@ -74,7 +75,7 @@ class MappingSingleOADim:
         )
 
     def __hash__(self):
-        return hash(frozenset(self.__data))
+        return hash_sha512(frozenset(self.__data))
 
 
 class SpatialMapping(LayerAttribute):
@@ -306,7 +307,7 @@ class SpatialMapping(LayerAttribute):
         )
 
     def __hash__(self):
-        return hash(frozenset(map(lambda x: (x[0], hash(x[1])), self.items())))
+        return hash_sha512(frozenset(map(lambda x: (x[0], hash_sha512(x[1])), self.items())))
 
     @staticmethod
     def empty() -> "SpatialMapping":

--- a/zigzag/utils.py
+++ b/zigzag/utils.py
@@ -1,15 +1,17 @@
 import logging
 import pickle
 from copy import deepcopy
+from hashlib import sha512
 from typing import Any
 
 import numpy as np
 import yaml
-from hashlib import sha512
+
 
 def hash_sha512(data: Any) -> int:
     """! Hashes the input data using SHA-512"""
     return int(sha512(pickle.dumps(data)).hexdigest(), 16)
+
 
 def pickle_deepcopy(to_copy: Any) -> Any:
     try:

--- a/zigzag/utils.py
+++ b/zigzag/utils.py
@@ -5,7 +5,11 @@ from typing import Any
 
 import numpy as np
 import yaml
+from hashlib import sha512
 
+def hash_sha512(data: Any) -> int:
+    """! Hashes the input data using SHA-512"""
+    return int(sha512(pickle.dumps(data)).hexdigest(), 16)
 
 def pickle_deepcopy(to_copy: Any) -> Any:
     try:


### PR DESCRIPTION
- Adds a hash_sha512 function in zigzag.utils.
- Replaces all standard Python hash() calls with hash_sha512  calls.

Python's hash function is randomized with a seed that differs from session to session. As a result, the hash of the same object will differ across sessions. This makes caching of intermediate data (as done in Stream) impossible.