### PR TITLE
Feed mem_type to MemoryFactory

### DIFF
--- a/zigzag/parser/accelerator_factory.py
+++ b/zigzag/parser/accelerator_factory.py
@@ -151,6 +151,7 @@ class MemoryFactory:
         return MemoryInstance(
             name=self.name,
             size=self.data["size"],
+            mem_type=self.data["mem_type"],
             r_bw=self.data["r_bw"],
             w_bw=self.data["w_bw"],
             r_cost=self.data["r_cost"],


### PR DESCRIPTION
Validator checks for mem_type, but it is not fed to MemoryFactory