### PR TITLE
Update get_total_inst_bandwidth function of CostModelEvaluation

### DIFF
--- a/zigzag/mapping/data_movement.py
+++ b/zigzag/mapping/data_movement.py
@@ -84,6 +84,9 @@ class FourWayDataMoving(Generic[T], metaclass=ABCMeta):
             self.wr_in_by_high * other,
         )
 
+    def __add__(self, other: "FourWayDataMoving[T]"):
+        return self._add_with_type(other, type(self))
+
     def __repr__(self):
         return (
             f"4waydatamoving (rd ^: {self.rd_out_to_high}, wr v: {self.wr_in_by_high}, "


### PR DESCRIPTION
Updates the `get_total_inst_bandwidth` function of the `CostModelEvaluation` type to:

- Correctly return the bandwidth in bits/cc as opposed to elements/cc
- Use the correct class type (FourWayDataMoving) instead of the subclass MemoryAccesses