### PR TITLE
Fix mapping bandwidth

### DIFF
--- a/tests/main/test_origin/test_ascend_like.py
+++ b/tests/main/test_origin/test_ascend_like.py
@@ -9,8 +9,8 @@ workloads = (
 
 # Expected energy and latency for each workload defined above
 ens_lats = {
-    "zigzag/inputs/workload/resnet18.onnx": (1940385435.76, 3028219.0),
-    "zigzag/inputs/workload/resnet18.yaml": (2449578483.76, 3974885.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1940385435.76, 3032311.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2449578483.76, 3980000.0),
 }
 
 

--- a/tests/main/test_origin/test_edge_tpu_like.py
+++ b/tests/main/test_origin/test_edge_tpu_like.py
@@ -9,8 +9,8 @@ workloads = (
 
 # Expected energy and latency for each workload defined above
 ens_lats = {
-    "zigzag/inputs/workload/resnet18.onnx": (1906107856.91, 2868613.5),
-    "zigzag/inputs/workload/resnet18.yaml": (2413348670.67, 3641431.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1903229377.55, 2887804.5),
+    "zigzag/inputs/workload/resnet18.yaml": (2413348670.67, 3741293.0),
 }
 
 

--- a/tests/main/test_origin/test_meta_prototype_like.py
+++ b/tests/main/test_origin/test_meta_prototype_like.py
@@ -9,8 +9,8 @@ workloads = (
 
 # Expected energy and latency for each workload defined above
 ens_lats = {
-    "zigzag/inputs/workload/resnet18.onnx": (1873660858.24, 2679987.16),
-    "zigzag/inputs/workload/resnet18.yaml": (2395695243.0, 3275453.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1863284164.16, 2700449.66),
+    "zigzag/inputs/workload/resnet18.yaml": (2373454257.72, 3316037.0),
 }
 
 

--- a/tests/main/test_origin/test_tesla_npu_like.py
+++ b/tests/main/test_origin/test_tesla_npu_like.py
@@ -9,8 +9,8 @@ workloads = (
 
 # Expected energy and latency for each workload defined above
 ens_lats = {
-    "zigzag/inputs/workload/resnet18.onnx": (1844670026.55, 2706356.5),
-    "zigzag/inputs/workload/resnet18.yaml": (2352110509.45, 3274219.66),
+    "zigzag/inputs/workload/resnet18.onnx": (1859923747.33, 2719709.75),
+    "zigzag/inputs/workload/resnet18.yaml": (2363901208.14, 3313105.91),
 }
 
 

--- a/tests/main/test_origin/test_tpu_like.py
+++ b/tests/main/test_origin/test_tpu_like.py
@@ -9,8 +9,8 @@ workloads = (
 
 # Expected energy and latency for each workload defined above
 ens_lats = {
-    "zigzag/inputs/workload/resnet18.onnx": (1871436380.66, 3685888.5),
-    "zigzag/inputs/workload/resnet18.yaml": (2610625982.61, 5516489.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1871436380.66, 3703960.5),
+    "zigzag/inputs/workload/resnet18.yaml": (2615172831.38, 5584991.0),
 }
 
 

--- a/tests/main/test_with_exploit_data_locality/test_ascend_like.py
+++ b/tests/main/test_with_exploit_data_locality/test_ascend_like.py
@@ -11,8 +11,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (5649553476, 8605524),
     "zigzag/inputs/workload/mobilenetv2.onnx": (1880536921, 6472147),
-    "zigzag/inputs/workload/resnet18.onnx": (1813915548.48, 3015266.0),
-    "zigzag/inputs/workload/resnet18.yaml": (2338798423.04, 3958170.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1813915548.47, 3017312.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2338798423.04, 3961239.0),
 }
 
 

--- a/tests/main/test_with_exploit_data_locality/test_edge_tpu_like.py
+++ b/tests/main/test_with_exploit_data_locality/test_edge_tpu_like.py
@@ -11,8 +11,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (5568602396.684999, 8134431),
     "zigzag/inputs/workload/mobilenetv2.onnx": (735250234.1699998, 2417321.0),
-    "zigzag/inputs/workload/resnet18.onnx": (1783892066.11, 2951044.5),
-    "zigzag/inputs/workload/resnet18.yaml": (2115121959.8699996, 3620941.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1783892066.11, 2957953.5),
+    "zigzag/inputs/workload/resnet18.yaml": (2115121959.87, 3706985.0),
 }
 
 

--- a/tests/main/test_with_exploit_data_locality/test_meta_prototype_like.py
+++ b/tests/main/test_with_exploit_data_locality/test_meta_prototype_like.py
@@ -11,8 +11,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (5679636177, 8279493),
     "zigzag/inputs/workload/mobilenetv2.onnx": (901087682, 2596085),
-    "zigzag/inputs/workload/resnet18.onnx": (1721342830.56, 2680789.5),
-    "zigzag/inputs/workload/resnet18.yaml": (2226399589.40, 3265450.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1710966136.48, 2689737.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2204158604.12, 3295822.0),
 }
 
 

--- a/tests/main/test_with_exploit_data_locality/test_tesla_npu_like.py
+++ b/tests/main/test_with_exploit_data_locality/test_tesla_npu_like.py
@@ -11,8 +11,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (6039993369, 8373281),
     "zigzag/inputs/workload/mobilenetv2.onnx": (930699349, 1955657),
-    "zigzag/inputs/workload/resnet18.onnx": (1709857690.01, 2701244.5),
-    "zigzag/inputs/workload/resnet18.yaml": (2201631649.06, 3262988.33),
+    "zigzag/inputs/workload/resnet18.onnx": (1725111410.78, 2709223.75),
+    "zigzag/inputs/workload/resnet18.yaml": (2213422347.76, 3296500.58),
 }
 
 

--- a/tests/main/test_with_exploit_data_locality/test_tpu_like.py
+++ b/tests/main/test_with_exploit_data_locality/test_tpu_like.py
@@ -11,8 +11,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (5475639039, 8963572),
     "zigzag/inputs/workload/mobilenetv2.onnx": (952681462, 21868059),
-    "zigzag/inputs/workload/resnet18.onnx": (1735241704.2240005, 3756282.50),
-    "zigzag/inputs/workload/resnet18.yaml": (2298383687.30, 5493246.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1735241704.22, 3762552.5),
+    "zigzag/inputs/workload/resnet18.yaml": (2302362179.97, 5548138.0),
 }
 
 

--- a/tests/main/test_with_mix_spatial_mapping/test_ascend_like.py
+++ b/tests/main/test_with_mix_spatial_mapping/test_ascend_like.py
@@ -13,8 +13,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (5664863934, 8479644),
     "zigzag/inputs/workload/mobilenetv2.onnx": (920740293, 3814440),
-    "zigzag/inputs/workload/resnet18.onnx": (1811468387.52, 3117931.33),
-    "zigzag/inputs/workload/resnet18.yaml": (2349013378.88, 3714899.66),
+    "zigzag/inputs/workload/resnet18.onnx": (1811468387.52, 3119977.33),
+    "zigzag/inputs/workload/resnet18.yaml": (2349013378.88, 3718548.66),
 }
 
 

--- a/tests/main/test_with_mix_spatial_mapping/test_edge_tpu_like.py
+++ b/tests/main/test_with_mix_spatial_mapping/test_edge_tpu_like.py
@@ -13,8 +13,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (6159980160, 8337351),
     "zigzag/inputs/workload/mobilenetv2.onnx": (742114179, 2421959),
-    "zigzag/inputs/workload/resnet18.onnx": (1735517944, 3834226.0),
-    "zigzag/inputs/workload/resnet18.yaml": (2029477205, 4509461.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1735517943.87, 3834226.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2029477205.31, 4586293.0),
 }
 
 

--- a/tests/main/test_with_mix_spatial_mapping/test_meta_prototype_like.py
+++ b/tests/main/test_with_mix_spatial_mapping/test_meta_prototype_like.py
@@ -13,8 +13,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (5681909132.480001, 8279495.0),
     "zigzag/inputs/workload/mobilenetv2.onnx": (909647916.68, 2602479.0),
-    "zigzag/inputs/workload/resnet18.onnx": (1746339277.28, 2685566.66),
-    "zigzag/inputs/workload/resnet18.yaml": (2250370155.48, 3247268.33),
+    "zigzag/inputs/workload/resnet18.onnx": (1746642408.16, 2688913.66),
+    "zigzag/inputs/workload/resnet18.yaml": (2249214190.04, 3278925.33),
 }
 
 

--- a/tests/main/test_with_mix_spatial_mapping/test_tesla_npu_like.py
+++ b/tests/main/test_with_mix_spatial_mapping/test_tesla_npu_like.py
@@ -14,7 +14,7 @@ ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (6006136982.778, 8290892.0),
     "zigzag/inputs/workload/mobilenetv2.onnx": (947736166.5380002, 1857838.0),
     "zigzag/inputs/workload/resnet18.onnx": (1599110638.5, 2318166.5),
-    "zigzag/inputs/workload/resnet18.yaml": (208430672325, 2889873.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2084306723.24, 2889873.0),
 }
 
 

--- a/tests/main/test_with_mix_spatial_mapping/test_tesla_npu_like.py
+++ b/tests/main/test_with_mix_spatial_mapping/test_tesla_npu_like.py
@@ -13,8 +13,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (6006136982.778, 8290892.0),
     "zigzag/inputs/workload/mobilenetv2.onnx": (947736166.5380002, 1857838.0),
-    "zigzag/inputs/workload/resnet18.onnx": (1611048997.07, 2295226.5),
-    "zigzag/inputs/workload/resnet18.yaml": (2101519570.14, 2841397.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1599110638.5, 2318166.5),
+    "zigzag/inputs/workload/resnet18.yaml": (208430672325, 2889873.0),
 }
 
 

--- a/tests/main/test_with_mix_spatial_mapping/test_tpu_like.py
+++ b/tests/main/test_with_mix_spatial_mapping/test_tpu_like.py
@@ -13,8 +13,8 @@ workloads = (
 ens_lats = {
     "zigzag/inputs/workload/alexnet.onnx": (5589583403, 8671208),
     "zigzag/inputs/workload/mobilenetv2.onnx": (932571650, 7304307),
-    "zigzag/inputs/workload/resnet18.onnx": (1759424218.3160002, 4250030.0),
-    "zigzag/inputs/workload/resnet18.yaml": (2191903732.78, 4601363.0),
+    "zigzag/inputs/workload/resnet18.onnx": (1759424218.32, 4256300.0),
+    "zigzag/inputs/workload/resnet18.yaml": (2191903732.78, 4657608.0),
 }
 
 

--- a/zigzag/cost_model/cost_model.py
+++ b/zigzag/cost_model/cost_model.py
@@ -1168,7 +1168,7 @@ class CostModelEvaluation(CostModelEvaluationABC):
         # we put it in the WR_IN_BY_HIGH direction if the output memory operand is present in the memory level.
         # Otherwise, we put it in the RD_OUT_TO_LOW direction.
         for port in memory_level.port_list:
-            if MemoryOperand("O") in memory_level.operands:
+            if Constants.OUTPUT_MEM_OP in memory_level.operands:
                 total_inst_bw.wr_in_by_high += self.total_loading_bw_during_computation[port]
             else:
                 total_inst_bw.rd_out_to_low += self.total_loading_bw_during_computation[port]

--- a/zigzag/mapping/data_movement.py
+++ b/zigzag/mapping/data_movement.py
@@ -127,14 +127,14 @@ class DataMovePattern:
 
     def __init__(self, operand: LayerOperand, mem_level: int):
         self.name = operand.name + str(mem_level)
-        self.data_elem_move_count = MemoryAccesses(0, 0, 0, 0)
-        self.data_precision = MemoryAccesses(0, 0, 0, 0)
-        self.req_mem_bw_aver = MemoryAccesses(0, 0, 0, 0)
-        self.req_mem_bw_inst = MemoryAccesses(0, 0, 0, 0)
-        self.data_trans_period = MemoryAccesses(0, 0, 0, 0)
-        self.data_trans_period_count = MemoryAccesses(0, 0, 0, 0)
-        self.data_trans_amount_per_period = MemoryAccesses(0, 0, 0, 0)
-        self.inst_data_trans_window = MemoryAccesses(0, 0, 0, 0)
+        self.data_elem_move_count = MemoryAccesses(0, 0, 0, 0)  # elements
+        self.data_precision = MemoryAccesses(0, 0, 0, 0)  # bits/element
+        self.req_mem_bw_aver = MemoryAccesses(0, 0, 0, 0)  # bits/cycle
+        self.req_mem_bw_inst = MemoryAccesses(0, 0, 0, 0)  # bits/cycle
+        self.data_trans_period = MemoryAccesses(0, 0, 0, 0)  # cycles
+        self.data_trans_period_count = MemoryAccesses(0, 0, 0, 0)  # periods
+        self.data_trans_amount_per_period = MemoryAccesses(0, 0, 0, 0)  # elements
+        self.inst_data_trans_window = MemoryAccesses(0, 0, 0, 0)  # cycles
 
     def set_data_elem_move_count(
         self,

--- a/zigzag/mapping/mapping.py
+++ b/zigzag/mapping/mapping.py
@@ -481,9 +481,10 @@ class Mapping:
         # e.g. for the DTL of Global Buffer (Weight) talking to spatially unrolled Weight Reg File,
         # each Weight Reg File's required write BW is indicated by "_L",
         # while Global Buffer (Weight)'s required read BW is indicate by "_H"
+        # The unit of these variables is bits per cycle
         req_mem_bw_low_raw = {
             op: [
-                data_each_level_unrolled[op][lv] / cycle_each_level[op][lv]
+                data_each_level_unrolled[op][lv] * self.data_precision_dict[op][lv] / cycle_each_level[op][lv]
                 for lv in range(self.spatial_mapping.arch_level[op])
             ]
             for op in self.operand_list


### PR DESCRIPTION
This PR fixes a part of the `unit_mem_data_movement` attribute of the Mapping object. 

Before, `unit_mem_data_movement` had a req_bw_aver and req_bw_inst which were elements/cycle. It is now fixed to be bits/cycle, as bandwidth is always represented as bits within ZigZag and that is also what is expected in the loading behavior calculation.

The expected test values change because the API call optimizes for latency, which can be different now that the bandwidth is taken into account correctly for the cycle borrowing from the computation phase for the loading phase.