### PR TITLE
Add cycles_per_op to cost model

### DIFF
--- a/tests/main/test_imc/test_aimc.py
+++ b/tests/main/test_imc/test_aimc.py
@@ -11,13 +11,13 @@ workloads = (
 ens_lats_clks_areas = {
     "zigzag/inputs/workload/resnet18.onnx": (
         4695729577.211851,
-        5540648.0,
+        5050846.0,
         14.07244,
         2.2878123152749223,
     ),
     "zigzag/inputs/workload/resnet18.yaml": (
         4264976904.6396008,
-        4907495.0,
+        4371385.0,
         14.07244,
         2.2878123152749223,
     ),

--- a/tests/main/test_imc/test_dimc.py
+++ b/tests/main/test_imc/test_dimc.py
@@ -11,13 +11,13 @@ workloads = (
 ens_lats_clks_areas = {
     "zigzag/inputs/workload/resnet18.onnx": (
         4726170712.825855,
-        6337728.0,
+        5681000.0,
         3.75708,
         0.8018113023999999,
     ),
     "zigzag/inputs/workload/resnet18.yaml": (
         4268285089.3547516,
-        5789229.0,
+        5114707.0,
         3.75708,
         0.8018113023999999,
     ),

--- a/zigzag/cost_model/cost_model.py
+++ b/zigzag/cost_model/cost_model.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from functools import lru_cache
 from math import ceil
-from typing import TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
 
@@ -19,6 +19,10 @@ from zigzag.mapping.spatial_mapping_internal import SpatialMappingInternal
 from zigzag.mapping.temporal_mapping import TemporalMapping
 from zigzag.utils import json_repr_handler, pickle_deepcopy
 from zigzag.workload.layer_node import LayerNode
+
+if TYPE_CHECKING:
+    from zigzag.workload.layer_attributes import MemoryOperandLinks
+
 
 logger = logging.getLogger(__name__)
 
@@ -294,6 +298,24 @@ class CostModelEvaluation(CostModelEvaluationABC):
     After initialization, the cost model evaluation is run.
     """
 
+    accelerator: Accelerator
+    layer: LayerNode
+    spatial_mapping: SpatialMappingInternal
+    temporal_mapping: TemporalMapping
+    access_same_data_considered_as_no_access: bool
+    cycles_per_op: float
+    mem_level_list: list[MemoryLevel]
+    mem_hierarchy_dict: dict[MemoryOperand, list[MemoryLevel]]
+    mem_size_dict: dict[MemoryOperand, list[int]]
+    mem_r_bw_dict: tuple[dict[MemoryOperand, list[int]], dict[MemoryOperand, list[int]]]
+    mem_r_bw_min_dict: tuple[dict[MemoryOperand, list[int]], dict[MemoryOperand, list[int]]]
+    mem_sharing_tuple: tuple[tuple[tuple[MemoryOperand, int], ...], ...]
+    memory_operand_links: "MemoryOperandLinks"
+    spatial_mapping_dict_int: Any
+    mapping: Mapping
+    mapping_int: Mapping
+    active_mem_level: dict[LayerOperand, int]
+
     def __init__(
         self,
         *,
@@ -317,7 +339,6 @@ class CostModelEvaluation(CostModelEvaluationABC):
         self.spatial_mapping_int = spatial_mapping_int  # the original spatial mapping without decimal
         self.temporal_mapping = temporal_mapping
         self.access_same_data_considered_as_no_access = access_same_data_considered_as_no_access
-
         self.mem_level_list = accelerator.memory_hierarchy.mem_level_list
         self.mem_hierarchy_dict = accelerator.mem_hierarchy_dict
         self.mem_size_dict = accelerator.mem_size_dict

--- a/zigzag/cost_model/cost_model.py
+++ b/zigzag/cost_model/cost_model.py
@@ -1010,9 +1010,7 @@ class CostModelEvaluation(CostModelEvaluationABC):
         for mem_op, mem_lv, mov_dir in combs_period_count_greater_than_1:
             layer_op = self.memory_operand_links.mem_to_layer_op(mem_op)
             req_bw_aver = unit_mem_data_movement[layer_op][mem_lv].req_mem_bw_aver.get_single_dir_data(mov_dir)
-            req_bw_aver = ceil(
-                req_bw_aver / self.cycles_per_op
-            )  # average bandwidth is lower for higher cycles_per_op
+            req_bw_aver = ceil(req_bw_aver / self.cycles_per_op)  # average bandwidth is lower for higher cycles_per_op
             total_req_bw_aver_computation += req_bw_aver
 
         data_loading += self.calc_loading_single_port_period_count_1(

--- a/zigzag/cost_model/cost_model_imc.py
+++ b/zigzag/cost_model/cost_model_imc.py
@@ -85,7 +85,8 @@ class CostModelEvaluationForIMC(CostModelEvaluation):
 
     def calc_latency(self):
         """!
-        The latency calculation is largely identical to that of the superclass, but with some modifications to fit the IMC requirement.
+        The latency calculation is largely identical to that of the superclass,
+        but with some modifications to fit the IMC requirement.
         """
         super().calc_double_buffer_flag()
         super().calc_allowed_and_real_data_transfer_cycle_per_data_transfer_link()


### PR DESCRIPTION
This PR adds a new attribute to the CostModelEvaluation (CME) object called `cycles_per_op`.

`cycles_per_op` can be used to represent higher number of cycles required to complete an operation (MAC, div, etc.).

In the past, this was represented through an input to the `calc_overall_latency()` function within the CME, but this didn't correctly modify the required memory bandwidths and in turn didn't correctly calculate the latency.

