### PR TITLE
Update workload equation regex

### DIFF
--- a/zigzag/parser/workload_validator.py
+++ b/zigzag/parser/workload_validator.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class WorkloadValidator:
     """Class to validate user-defined workloads from yaml files according to the given schema and rules"""
 
-    EQUATION_REGEX = r"^O(\[\w+\])+\+?=\w(\[\w+\])+[*+]\w(\[(?:\w+)?\])+$"
+    EQUATION_REGEX = r"^O(\[\w+\])+\s*\+?\s*=\s*\w(\[\w+\])+\s*[*+]\s*\w(\[(?:\w+)?\])+\s*$"
     LAYER_DIM_RELATION_REGEX = r"^(\w+)\s*=\s*(?:(\w+)\s*\*\s*)?(\w+)\s*\+\s*(?:(\w+)\s*\*\s*)?(\w+)$"
     ALLOWED_OPERATORS: list[str] = [
         "Max",


### PR DESCRIPTION
Allows spaces to be used in the workload equation between operators (+, *, +=). This makes it more robust for user-defined workloads.