### PR TITLE
Allow different bandwidth per MemoryPort

### DIFF
--- a/zigzag/cost_model/cost_model.py
+++ b/zigzag/cost_model/cost_model.py
@@ -504,6 +504,7 @@ class CostModelEvaluation(CostModelEvaluationABC):
                         else:
                             raise ValueError(f"Memory bandwidth not defined for {mem_level} {mem_op} {data_dir}")
                     else:
+                        assert max_bw and min_bw, f"Memory bandwidth not defined for {mem_level} {mem_op} {data_dir}"
                         memory_accesses[data_dir] = self._calc_memory_access(
                             amount,
                             precision,

--- a/zigzag/cost_model/cost_model.py
+++ b/zigzag/cost_model/cost_model.py
@@ -1128,12 +1128,12 @@ class CostModelEvaluation(CostModelEvaluationABC):
         memory_levels = self.accelerator.memory_hierarchy.get_memory_levels(memory_operand)
         memory_level_index = memory_levels.index(memory_level)
         # Obtain the required instantaneous bandwidth to/from the memory for its operands during computation
-        inst_bw = FourWayDataMoving({dir: 0 for dir in DataDirection})
+        inst_bw = FourWayDataMoving({data_dir: 0 for data_dir in DataDirection})
         layer_op = self.memory_operand_links.mem_to_layer_op(memory_operand)
         umdm = self.mapping_int.unit_mem_data_movement[layer_op][memory_level_index]
         req_bw_4way = umdm.get_attribute(DataMoveAttr.REQ_MEM_BW_INST)
         scaled_bw = FourWayDataMoving(
-            {dir: ceil(req_bw_4way.get(dir) * scaling / self.cycles_per_op) for dir in DataDirection}
+            {data_dir: ceil(req_bw_4way.get(data_dir) * scaling / self.cycles_per_op) for data_dir in DataDirection}
         )
         inst_bw += scaled_bw
         ## LOADING PHASE BORROWED BANDWIDTH
@@ -1160,7 +1160,7 @@ class CostModelEvaluation(CostModelEvaluationABC):
         if the given memory level is not included in this CME's memory hierarchy.
         NOTE: this function is used in Stream
         """
-        total_inst_bw = FourWayDataMoving({dir: 0 for dir in DataDirection})
+        total_inst_bw = FourWayDataMoving({data_dir: 0 for data_dir in DataDirection})
         for mem_op in memory_level.operands:
             total_inst_bw += self.get_inst_bandwidth(memory_level, mem_op, scaling)
         return total_inst_bw

--- a/zigzag/cost_model/cost_model.py
+++ b/zigzag/cost_model/cost_model.py
@@ -498,15 +498,21 @@ class CostModelEvaluation(CostModelEvaluationABC):
                     period_count = data_trans_period_count.get(data_dir)
                     max_bw = mem_level.get_max_bandwidth(mem_op, data_dir)
                     min_bw = mem_level.get_min_bandwidth(mem_op, data_dir)
-                    memory_accesses[data_dir] = self._calc_memory_access(
-                        amount,
-                        precision,
-                        period_count,
-                        max_bw,
-                        min_bw,
-                        layer_op,
-                        mem_lvl_id,
-                    )
+                    if min_bw is None and max_bw is None:
+                        if amount == 0:
+                            memory_accesses[data_dir] = 0
+                        else:
+                            raise ValueError(f"Memory bandwidth not defined for {mem_level} {mem_op} {data_dir}")
+                    else:
+                        memory_accesses[data_dir] = self._calc_memory_access(
+                            amount,
+                            precision,
+                            period_count,
+                            max_bw,
+                            min_bw,
+                            layer_op,
+                            mem_lvl_id,
+                        )
                 memory_word_access[layer_op].append(MemoryAccesses(memory_accesses))
         self.memory_word_access = memory_word_access
 

--- a/zigzag/hardware/architecture/accelerator.py
+++ b/zigzag/hardware/architecture/accelerator.py
@@ -72,7 +72,6 @@ class Accelerator:
                 if mem_op in node.operands
             ]
 
-
     def __generate_mem_sharing_list(self):
         """! Generates a list of dictionary that indicates which operand's which memory levels are sharing the same
         physical memory"""

--- a/zigzag/hardware/architecture/accelerator.py
+++ b/zigzag/hardware/architecture/accelerator.py
@@ -71,26 +71,7 @@ class Accelerator:
                 for node in self.memory_hierarchy.topological_sort()
                 if mem_op in node.operands
             ]
-            self.mem_r_bw_dict[mem_op] = [
-                node.memory_instance.r_bw
-                for node in self.memory_hierarchy.topological_sort()
-                if mem_op in node.operands
-            ]
-            self.mem_w_bw_dict[mem_op] = [
-                node.memory_instance.w_bw
-                for node in self.memory_hierarchy.topological_sort()
-                if mem_op in node.operands
-            ]
-            self.mem_r_bw_min_dict[mem_op] = [
-                node.memory_instance.r_bw_min
-                for node in self.memory_hierarchy.topological_sort()
-                if mem_op in node.operands
-            ]
-            self.mem_w_bw_min_dict[mem_op] = [
-                node.memory_instance.w_bw_min
-                for node in self.memory_hierarchy.topological_sort()
-                if mem_op in node.operands
-            ]
+
 
     def __generate_mem_sharing_list(self):
         """! Generates a list of dictionary that indicates which operand's which memory levels are sharing the same

--- a/zigzag/hardware/architecture/memory_instance.py
+++ b/zigzag/hardware/architecture/memory_instance.py
@@ -17,7 +17,7 @@ class MemoryInstance:
     w_port: int
     rw_port: int
     latency: int
-    ports: tuple[MemoryPort]
+    ports: tuple[MemoryPort, ...]
     mem_type: str
     auto_cost_extraction: bool
     double_buffering_support: bool
@@ -34,9 +34,7 @@ class MemoryInstance:
         w_port: int = 1,
         rw_port: int = 0,
         latency: int = 1,
-        ports: list[MemoryPort] = [],
-        min_r_granularity: int | None = None,
-        min_w_granularity: int | None = None,
+        ports: tuple[MemoryPort, ...] = tuple(),
         mem_type: str = "sram",
         auto_cost_extraction: bool = False,
         double_buffering_support: bool = False,

--- a/zigzag/hardware/architecture/memory_instance.py
+++ b/zigzag/hardware/architecture/memory_instance.py
@@ -1,5 +1,5 @@
 from zigzag.cacti.cacti_parser import CactiParser
-from zigzag.hardware.architecture.memory_port import MemoryPort
+from zigzag.hardware.architecture.memory_port import MemoryPort, MemoryPortType
 from zigzag.utils import json_repr_handler
 
 
@@ -56,7 +56,13 @@ class MemoryInstance:
             memory between two cores (feature used in Stream).
         """
         if auto_cost_extraction:
-            r_bw = next(port.bw_max for port in ports if port.type == "read")
+            try:
+                r_bw = next(port.bw_max for port in ports if port.type == MemoryPortType.READ)
+            except StopIteration:
+                try:
+                    r_bw = next(port.bw_max for port in ports if port.type == MemoryPortType.READ_WRITE)
+                except StopIteration:
+                    raise ValueError(f"MemoryInstance {name} does not have a read or read_write port.")
             cacti_parser = CactiParser()
             r_cost, w_cost, area = cacti_parser.get_item(
                 mem_name=name,

--- a/zigzag/hardware/architecture/memory_instance.py
+++ b/zigzag/hardware/architecture/memory_instance.py
@@ -1,4 +1,5 @@
 from zigzag.cacti.cacti_parser import CactiParser
+from zigzag.hardware.architecture.memory_port import MemoryPort
 from zigzag.utils import json_repr_handler
 
 
@@ -16,26 +17,7 @@ class MemoryInstance:
     w_port: int
     rw_port: int
     latency: int
-    min_r_granularity: int
-    min_w_granularity: int
-    mem_type: str
-    auto_cost_extraction: bool
-    double_buffering_support: bool
-    shared_memory_group_id: int
-
-    name: str
-    size: int
-    r_bw: int
-    w_bw: int
-    r_cost: float
-    w_cost: float
-    area: float
-    r_port: int
-    w_port: int
-    rw_port: int
-    latency: int
-    min_r_granularity: int
-    min_w_granularity: int
+    ports: tuple[MemoryPort]
     mem_type: str
     auto_cost_extraction: bool
     double_buffering_support: bool
@@ -45,8 +27,6 @@ class MemoryInstance:
         self,
         name: str,
         size: int,
-        r_bw: int,
-        w_bw: int = 0,
         r_cost: float = 0,
         w_cost: float = 0,
         area: float = 0,
@@ -54,6 +34,7 @@ class MemoryInstance:
         w_port: int = 1,
         rw_port: int = 0,
         latency: int = 1,
+        ports: list[MemoryPort] = [],
         min_r_granularity: int | None = None,
         min_w_granularity: int | None = None,
         mem_type: str = "sram",
@@ -68,14 +49,8 @@ class MemoryInstance:
         @param r_bw/w_bw: memory bandwidth (or word length) (unit: bit/cycle).
         @param r_cost/w_cost: memory unit data access energy (unit: pJ/access).
         @param area: memory area (unit can be whatever user-defined unit).
-        @param r_port: number of memory read port.
-        @param w_port: number of memory write port (rd_port and wr_port can work in parallel).
-        @param rw_port: number of memory port for both read and write (read and write cannot happen in parallel).
         @param latency: memory access latency (unit: number of cycles).
-        @param min_r_granularity (int): The minimal number of bits than can be read in a clock cycle (can be a less than
-          r_bw)
-        @param min_w_granularity (int): The minimal number of bits that can be written in a clock cycle (can be less
-        than w_bw)
+        @param ports: tuple of MemoryPort instances.
         @param mem_type (str): The type of memory. Used for CACTI cost extraction.
         @param auto_cost_extraction (bool): Automatically extract the read cost, write cost and area using CACTI.
         @param double_buffering_support (bool): Support for double buffering on this memory instance.
@@ -83,6 +58,7 @@ class MemoryInstance:
             memory between two cores (feature used in Stream).
         """
         if auto_cost_extraction:
+            r_bw = next(port.bw_max for port in ports if port.type == "read")
             cacti_parser = CactiParser()
             r_cost, w_cost, area = cacti_parser.get_item(
                 mem_name=name,
@@ -97,20 +73,13 @@ class MemoryInstance:
 
         self.name = name
         self.size = size
-        self.r_bw = r_bw
-        self.w_bw = w_bw
         self.r_cost = r_cost
         self.w_cost = w_cost
         self.area = area
-        self.r_port_nb = r_port
-        self.w_port_nb = w_port
-        self.rw_port_nb = rw_port
         self.latency = latency
+        self.ports = ports
         self.double_buffering_support = double_buffering_support
         self.shared_memory_group_id = shared_memory_group_id
-
-        self.r_bw_min: int = min_r_granularity if min_r_granularity is not None else r_bw
-        self.w_bw_min: int = min_w_granularity if min_w_granularity is not None else w_bw
 
     def update_size(self, new_size: int) -> None:
         """! Update the memory size of this instance."""
@@ -128,17 +97,11 @@ class MemoryInstance:
         differs from __eq__ since it does not consider e.g. the shared_memory_group_id"""
         return (
             self.size == other.size
-            and self.r_bw == other.r_bw
-            and self.w_bw == other.w_bw
             and self.r_cost == other.r_cost
             and self.w_cost == other.w_cost
-            and self.r_port_nb == other.r_port_nb
-            and self.w_port_nb == other.w_port_nb
-            and self.rw_port_nb == other.rw_port_nb
             and self.latency == other.latency
+            and self.ports == other.ports
             and self.double_buffering_support == other.double_buffering_support
-            and self.r_bw_min == other.r_bw_min
-            and self.w_bw_min == other.w_bw_min
         )
 
     def __hash__(self):

--- a/zigzag/hardware/architecture/memory_level.py
+++ b/zigzag/hardware/architecture/memory_level.py
@@ -6,7 +6,6 @@ from zigzag.hardware.architecture.memory_instance import MemoryInstance
 from zigzag.hardware.architecture.memory_port import (
     DataDirection,
     MemoryPort,
-    MemoryPortType,
     PortAllocation,
 )
 from zigzag.hardware.architecture.operational_array import OperationalArrayABC
@@ -105,14 +104,13 @@ class MemoryLevel:
         for mem_op, mem_lvl in self.mem_level_of_operands.items():
             allocation_this_mem_op = self.port_alloc_raw.get_alloc_for_mem_op(mem_op)
             for direction, port_name in allocation_this_mem_op.items():
-            # Add operand, memory level, and served data movement direction for each port.
+                # Add operand, memory level, and served data movement direction for each port.
                 port_idx = port_names.index(port_name)
                 mem_port = self.ports[port_idx]
                 mem_port.add_port_function((mem_op, mem_lvl, direction))
                 # Save bandwidth for this mem_op and direction for faster access later.
                 self.bandwidths_min[mem_op][direction] = mem_port.bw_min
                 self.bandwidths_max[mem_op][direction] = mem_port.bw_max
-
 
     def get_min_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int:
         """! Get the minimum memory bandwidth for a specific memory operand and data movement direction"""

--- a/zigzag/hardware/architecture/memory_level.py
+++ b/zigzag/hardware/architecture/memory_level.py
@@ -112,13 +112,13 @@ class MemoryLevel:
                 self.bandwidths_min[mem_op][direction] = mem_port.bw_min
                 self.bandwidths_max[mem_op][direction] = mem_port.bw_max
 
-    def get_min_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int | None:
+    def get_min_bandwidth(self, operand: MemoryOperand, data_dir: DataDirection) -> int | None:
         """! Get the minimum memory bandwidth for a specific memory operand and data movement direction"""
-        return self.bandwidths_min[operand][dir]
+        return self.bandwidths_min[operand][data_dir]
 
-    def get_max_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int | None:
+    def get_max_bandwidth(self, operand: MemoryOperand, data_dir: DataDirection) -> int | None:
         """! Get the maximum memory bandwidth for a specific memory operand and data movement direction"""
-        return self.bandwidths_max[operand][dir]
+        return self.bandwidths_max[operand][data_dir]
 
     @property
     def unroll_count(self) -> int:

--- a/zigzag/hardware/architecture/memory_level.py
+++ b/zigzag/hardware/architecture/memory_level.py
@@ -4,6 +4,7 @@ from typing import Any
 from zigzag.datatypes import MemoryOperand, OADimension
 from zigzag.hardware.architecture.memory_instance import MemoryInstance
 from zigzag.hardware.architecture.memory_port import (
+    DataDirection,
     MemoryPort,
     MemoryPortType,
     PortAllocation,
@@ -61,7 +62,7 @@ class MemoryLevel:
     write_energy: float
     read_bw: float
     write_bw: float
-    port_list: list[MemoryPort]
+    ports: list[MemoryPort]
 
     def __init__(
         self,
@@ -87,57 +88,39 @@ class MemoryLevel:
 
         # for each operand that current memory level holds, allocate physical memory ports to its 4 potential data
         # movement
+        self.ports = memory_instance.ports
         self.port_alloc_raw = port_alloc
         self.__allocate_ports()
 
         #  memory access bandwidth and energy extraction
         self.read_energy = memory_instance.r_cost
         self.write_energy = memory_instance.w_cost
-        self.read_bw = memory_instance.r_bw
-        self.write_bw = memory_instance.w_bw
 
     def __allocate_ports(self):
-        # Step 1: according to the port count of the memory instance, initialize the physical port object
-        # (so far, we don't know what the port will be used for. But we do know the port's id/bw/attribute)
-        port_list: list[MemoryPort] = []
-        r_port_nb = self.memory_instance.r_port_nb
-        w_port_nb = self.memory_instance.w_port_nb
-        rw_port_nb = self.memory_instance.rw_port_nb
-        for i in range(1, r_port_nb + 1):
-            port_name = "r_port_" + str(i)
-            port_bw = self.memory_instance.r_bw
-            port_bw_min = self.memory_instance.r_bw_min
-            port_attr = MemoryPortType.READ
-            new_port = MemoryPort(port_name, port_bw, port_bw_min, port_attr)
-            port_list.append(new_port)
-        for i in range(1, w_port_nb + 1):
-            port_name = "w_port_" + str(i)
-            port_bw = self.memory_instance.w_bw
-            port_bw_min = self.memory_instance.w_bw_min
-            port_attr = MemoryPortType.WRITE
-            new_port = MemoryPort(port_name, port_bw, port_bw_min, port_attr)
-            port_list.append(new_port)
-        for i in range(1, rw_port_nb + 1):
-            port_name = "rw_port_" + str(i)
-            # we assume the read-write port has the same bw for read and write
-            port_bw = self.memory_instance.r_bw
-            # we assume the read-write port has the same bw for read and write
-            port_bw = self.memory_instance.r_bw
-            port_bw_min = self.memory_instance.r_bw_min
-            port_attr = MemoryPortType.READ_WRITE
-            new_port = MemoryPort(port_name, port_bw, port_bw_min, port_attr)
-            port_list.append(new_port)
-        port_names = [port.name for port in port_list]
-
-        # Step 2: add operand, memory level, and served data movement direction for each port.
+        port_names = [port.name for port in self.ports]
+        self.bandwidths_min: dict[MemoryOperand, dict[DataDirection, int]]
+        self.bandwidths_max: dict[MemoryOperand, dict[DataDirection, int]]
+        self.bandwidths_min = {op: {data_dir: None for data_dir in DataDirection} for op in self.operands}
+        self.bandwidths_max = {op: {data_dir: None for data_dir in DataDirection} for op in self.operands}
         for mem_op, mem_lvl in self.mem_level_of_operands.items():
             allocation_this_mem_op = self.port_alloc_raw.get_alloc_for_mem_op(mem_op)
             for direction, port_name in allocation_this_mem_op.items():
+            # Add operand, memory level, and served data movement direction for each port.
                 port_idx = port_names.index(port_name)
-                mem_port = port_list[port_idx]
+                mem_port = self.ports[port_idx]
                 mem_port.add_port_function((mem_op, mem_lvl, direction))
+                # Save bandwidth for this mem_op and direction for faster access later.
+                self.bandwidths_min[mem_op][direction] = mem_port.bw_min
+                self.bandwidths_max[mem_op][direction] = mem_port.bw_max
 
-        self.port_list = port_list
+
+    def get_min_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int:
+        """! Get the minimum memory bandwidth for a specific memory operand and data movement direction"""
+        return self.bandwidths_min[operand][dir]
+
+    def get_max_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int:
+        """! Get the maximum memory bandwidth for a specific memory operand and data movement direction"""
+        return self.bandwidths_max[operand][dir]
 
     @property
     def unroll_count(self) -> int:
@@ -173,7 +156,7 @@ class MemoryLevel:
             and self.memory_instance == other.memory_instance
             and self.operands == other.operands
             and self.mem_level_of_operands == other.mem_level_of_operands
-            and self.port_list == other.port_list
+            and self.ports == other.ports
             and self.served_dimensions == other.served_dimensions
         )
 
@@ -182,7 +165,7 @@ class MemoryLevel:
             self.memory_instance.has_same_performance(other.memory_instance)
             and self.operands == other.operands
             and self.mem_level_of_operands == other.mem_level_of_operands
-            and self.port_list == other.port_list
+            and self.ports == other.ports
             and self.served_dimensions == other.served_dimensions
         )
 

--- a/zigzag/hardware/architecture/memory_level.py
+++ b/zigzag/hardware/architecture/memory_level.py
@@ -61,7 +61,7 @@ class MemoryLevel:
     write_energy: float
     read_bw: float
     write_bw: float
-    ports: list[MemoryPort]
+    ports: tuple[MemoryPort, ...]
 
     def __init__(
         self,

--- a/zigzag/hardware/architecture/memory_level.py
+++ b/zigzag/hardware/architecture/memory_level.py
@@ -112,11 +112,11 @@ class MemoryLevel:
                 self.bandwidths_min[mem_op][direction] = mem_port.bw_min
                 self.bandwidths_max[mem_op][direction] = mem_port.bw_max
 
-    def get_min_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int:
+    def get_min_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int | None:
         """! Get the minimum memory bandwidth for a specific memory operand and data movement direction"""
         return self.bandwidths_min[operand][dir]
 
-    def get_max_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int:
+    def get_max_bandwidth(self, operand: MemoryOperand, dir: DataDirection) -> int | None:
         """! Get the maximum memory bandwidth for a specific memory operand and data movement direction"""
         return self.bandwidths_max[operand][dir]
 

--- a/zigzag/hardware/architecture/memory_port.py
+++ b/zigzag/hardware/architecture/memory_port.py
@@ -7,9 +7,9 @@ from zigzag.parser.accelerator_validator import AcceleratorValidator
 
 
 class MemoryPortType(StrEnum):
-    READ = "r"
-    WRITE = "w"
-    READ_WRITE = "rw"
+    READ = "read"
+    WRITE = "write"
+    READ_WRITE = "read_write"
 
 
 class DataDirection(StrEnum):
@@ -31,22 +31,23 @@ class MemoryPort:
     def __init__(
         self,
         port_name: str,
-        port_bw: int,
-        port_bw_min: int,
-        port_attr: MemoryPortType,
+        type: MemoryPortType,
+        bandwidth_min: int,
+        bandwidth_max: int,
         port_id: int | None = None,
     ):
         """
         Collect all the physical memory port related information here.
         @param port_name:
-        @param port_bw: bit/cc
-        @param port_attr: read_only (r), write_only (w), read_write (rw)
+        @param bandwidth_min: bit/cc
+        @param bandwidth_max: bit/cc
+        @param type: read_only (read), write_only (write), read_write (read_write)
         @param port_id: port index per memory
         """
         self.name = port_name
-        self.bw = port_bw
-        self.bw_min = port_bw_min
-        self.attr = port_attr
+        self.bw_min = bandwidth_min
+        self.bw_max = bandwidth_max
+        self.type = type
         self.served_op_lv_dir: list[OperandDirection] = []
 
         #  to give each port a unique id number
@@ -74,9 +75,9 @@ class MemoryPort:
     def __eq__(self, other: Any) -> bool:
         return (
             isinstance(other, MemoryPort)
-            and self.bw == other.bw
+            and self.bw_max == other.bw_max
             and self.bw_min == other.bw_min
-            and self.attr == other.attr
+            and self.type == other.type
         )
 
     def __hash__(self):

--- a/zigzag/inputs/hardware/aimc.yaml
+++ b/zigzag/inputs/hardware/aimc.yaml
@@ -3,101 +3,124 @@ name: aimc
 memories:
   cells:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0
     w_cost: 0.095
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 0
     operands: [I2]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
+          - I2, tl
     served_dimensions: [] # Fully unrolled over all multipliers
 
   rf_1B:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0.021
     w_cost: 0.021
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
     operands: [I1]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I1, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I1, fh
     served_dimensions: [D1]
 
   rf_2B:
     size: 16
-    r_bw: 16
-    w_bw: 16
     r_cost: 0.021
     w_cost: 0.021
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fl
     served_dimensions: [D2]
 
   sram_256KB:
     size: 262144
-    r_bw: 512
-    w_bw: 512
     r_cost: 416.16
     w_cost: 378.4
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1, O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 700
     w_cost: 750
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
 operational_array:

--- a/zigzag/inputs/hardware/ascend_like.yaml
+++ b/zigzag/inputs/hardware/ascend_like.yaml
@@ -3,162 +3,197 @@ name: ascend_like
 memories:
   rf_1B:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0.01
     w_cost: 0.01
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
     served_dimensions: [D3, D4]
 
   rf_2B:
     size: 16
-    r_bw: 16
-    w_bw: 16
     r_cost: 0.02
     w_cost: 0.02
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fl
     served_dimensions: [D2]
 
   rf_64KB_I:
     size: 65536
-    r_bw: 512
-    w_bw: 512
     r_cost: 26.56
     w_cost: 30.72
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I1, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I1, fh
     served_dimensions: [D1, D2, D3, D4]
 
   rf_64KB_W:
     size: 65536
-    r_bw: 2048
-    w_bw: 2048
     r_cost: 50.16
     w_cost: 108.0
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2, D3, D4]
 
   sram_256KB_O:
     size: 2097152
-    r_bw: 2048
-    w_bw: 2048
     r_cost: 123.2
     w_cost: 212.8
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2, D3, D4]
 
   sram_1MB_A:
     size: 8388608
-    r_bw: 4096
-    w_bw: 4096
     r_cost: 465.6
     w_cost: 825.6
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
-    min_r_granularity: 64
-    min_w_granularity: 64
     latency: 1
     operands: [I1, O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 4096
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 4096
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2, D3, D4]
 
   sram_1MB_W:
     size: 8388608
-    r_bw: 4096
-    w_bw: 4096
     r_cost: 465.6
     w_cost: 825.6
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
-    min_r_granularity: 64
-    min_w_granularity: 64
     latency: 1
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 4096
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 4096
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2, D3, D4]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 700
     w_cost: 750
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
 operational_array:

--- a/zigzag/inputs/hardware/dimc.yaml
+++ b/zigzag/inputs/hardware/dimc.yaml
@@ -3,101 +3,124 @@ name: dimc
 memories:
   cells:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0
     w_cost: 0.095
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 0
     operands: [I2]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
+          - I2, tl
     served_dimensions: [] # Fully unrolled over all multipliers
 
   rf_1B:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0.021
     w_cost: 0.021
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
     operands: [I1]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I1, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I1, fh
     served_dimensions: [D1]
 
   rf_2B:
     size: 16
-    r_bw: 16
-    w_bw: 16
     r_cost: 0.021
     w_cost: 0.021
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fl
     served_dimensions: [D2]
 
   sram_256KB:
     size: 262144
-    r_bw: 512
-    w_bw: 512
     r_cost: 416.16
     w_cost: 378.4
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1, O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 700
     w_cost: 750
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
 operational_array:

--- a/zigzag/inputs/hardware/edge_tpu_like.yaml
+++ b/zigzag/inputs/hardware/edge_tpu_like.yaml
@@ -3,104 +3,129 @@ name: edge_tpu_like
 memories:
   rf_1B:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0.01
     w_cost: 0.01
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    auto_cost_extraction: False
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
     served_dimensions: [D3, D4]
 
   rf_2B:
     size: 16
-    r_bw: 16
-    w_bw: 16
     r_cost: 0.02
     w_cost: 0.02
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fl
     served_dimensions: [D2]
 
   sram_32KB:
     size: 262144
-    r_bw: 512
-    w_bw: 512
     r_cost: 22.9
     w_cost: 52.01
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2, D3, D4]
 
   sram_2MB:
     size: 16777216
-    r_bw: 2048
-    w_bw: 2048
     r_cost: 416.16
     w_cost: 378.4
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1, O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2, D3, D4]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 700
     w_cost: 750
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2, D3, D4]
 
 operational_array:

--- a/zigzag/inputs/hardware/eyeriss_like.yaml
+++ b/zigzag/inputs/hardware/eyeriss_like.yaml
@@ -3,135 +3,155 @@ name: eyeriss_like
 memories:
   rf_64B_A:
     size: 512
-    r_bw: 8
-    w_bw: 8
     r_cost: 1.0
     w_cost: 1.5
     area: 0.3
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
     operands: [I1]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I1, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I1, fh
     served_dimensions: []
 
   rf_64B_W:
     size: 512
-    r_bw: 8
-    w_bw: 8
     r_cost: 1.0
     w_cost: 1.5
     area: 0.3
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
     served_dimensions: []
 
   rf_16B:
     size: 128
-    r_bw: 24
-    w_bw: 24
     r_cost: 1.5
     w_cost: 2.0
     area: 0.95
-    r_port: 1
-    w_port: 1
-    rw_port: 1
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 24
+        bandwidth_max: 24
+        allocation: 
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 24
+        bandwidth_max: 24
+        allocation: 
+          - O, fh
+          - O, fl
     served_dimensions: []
 
   sram_8KB:
     size: 65536
-    r_bw: 128
-    w_bw: 128
     r_cost: 10.0
     w_cost: 15.0
     area: 3
-    r_port: 0
-    w_port: 1
-    rw_port: 2
     latency: 1
     operands: [O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_2
-        fl: rw_port_2
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 128
+        bandwidth_max: 128
+        allocation: 
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
   sram_64KB:
     size: 524288
-    r_bw: 128
-    w_bw: 128
     r_cost: 20
     w_cost: 25
     area: 6
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 128
+        bandwidth_max: 128
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 128
+        bandwidth_max: 128
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2]
 
   sram_1M:
     size: 8388608
-    r_bw: 384
-    w_bw: 384
     r_cost: 100
     w_cost: 130
     area: 25
-    r_port: 0
-    w_port: 0
-    rw_port: 2
     latency: 1
     operands: [I1, O]
     ports:
-      - fh: rw_port_1
-        tl: wr_port_2
-      - fh: rw_port_1
-        tl: rw_port_2
-        fl: rw_port_2
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 384
+        bandwidth_max: 384
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 1000
     w_cost: 1000
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
 operational_array:

--- a/zigzag/inputs/hardware/generic_array_cacti.yaml
+++ b/zigzag/inputs/hardware/generic_array_cacti.yaml
@@ -10,93 +10,145 @@ name: generic_array
 memories:
   rf_I:
     size: 1024
-    r_bw: 16
-    w_bw: 16
-    auto_cost_extraction: true
-    r_port: 1
-    w_port: 1
-    rw_port: 0
+    r_cost: 0.095
+    w_cost: 0.095
+    area: 0
     latency: 1
     operands: [I1]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - I1, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - I1, fh
     served_dimensions: []
 
   rf_W: # For MatMul, this will store activations
     size: 1024
-    r_bw: 16
-    w_bw: 16
-    auto_cost_extraction: true
-    r_port: 1
-    w_port: 1
-    rw_port: 0
+    r_cost: 0.095
+    w_cost: 0.095
+    area: 0
     latency: 1
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - I2, fh
     served_dimensions: []
 
   rf_O:
     size: 1024
-    r_bw: 32
-    w_bw: 32
-    auto_cost_extraction: true
-    r_port: 2
-    w_port: 2
-    rw_port: 0
+    r_cost: 0.095
+    w_cost: 0.095
+    area: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, fl
     served_dimensions: []
 
   sram_32MB: # From FLAT paper: 8 Tbit/s on-chip BW
-    size: 268_435_456
-    r_bw: 16384 #65_536 #2048
-    w_bw: 16384 #65_536 #2048
-    auto_cost_extraction: true
-    r_port: 2 # 1
-    w_port: 2 # 1
-    rw_port: 0
+    size: 268435456
+    r_cost: 416.16
+    w_cost: 378.4
+    area: 0
     latency: 1
-    # min_r_granularity: 64 # Does this make sense?
-    # min_w_granularity: 64
     operands: [I1, I2, O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-      - fh: w_port_2
-        tl: r_port_2
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 16384
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: r_port_2
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 16384
+        allocation: 
+          - I2, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 16384
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
+      - name: w_port_2
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 16384
+        allocation: 
+          - I2, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2]
 
   dram: # 400 GB/s
     size: 10000000000
-    r_bw: 2048 # 64
-    w_bw: 2048 # 64
-    auto_cost_extraction: true
-    r_port: 0
-    w_port: 0
-    rw_port: 1
+    r_cost: 700
+    w_cost: 750
+    area: 0
     latency: 10
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
 operational_array:

--- a/zigzag/inputs/hardware/meta_prototype.yaml
+++ b/zigzag/inputs/hardware/meta_prototype.yaml
@@ -3,142 +3,173 @@ name: meta_prototype
 memories:
   rf_1B:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0.01
     w_cost: 0.01
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    auto_cost_extraction: False
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
     served_dimensions: [D3, D4]
 
   rf_2B:
     size: 16
-    r_bw: 16
-    w_bw: 16
     r_cost: 0.02
     w_cost: 0.02
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fl
     served_dimensions: [D2]
 
   sram_64KB:
     size: 524288
-    r_bw: 512
-    w_bw: 512
     r_cost: 26.56
     w_cost: 30.8
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 512
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2, D3, D4]
 
   sram_32KB:
     size: 262144
-    r_bw: 256
-    w_bw: 256
     r_cost: 13.28
     w_cost: 15.4
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 256
+        allocation: 
+          - I1, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 256
+        allocation: 
+          - I1, fh
     served_dimensions: [D1, D2, D3, D4]
 
   sram_1MB_A:
     size: 8388608
-    r_bw: 1024
-    w_bw: 1024
     r_cost: 208.08
     w_cost: 189.2
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1, O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2, D3, D4]
 
   sram_1MB_W:
     size: 8388608
-    r_bw: 1024
-    w_bw: 1024
     r_cost: 208.08
     w_cost: 189.2
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2, D3, D4]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 700
     w_cost: 750
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2, D3, D4]
 
 operational_array:

--- a/zigzag/inputs/hardware/tesla_npu_like.yaml
+++ b/zigzag/inputs/hardware/tesla_npu_like.yaml
@@ -3,142 +3,173 @@ name: npu_like
 memories:
   rf_1B:
     size: 8
-    r_bw: 8
-    w_bw: 8
     r_cost: 0.01
     w_cost: 0.01
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    auto_cost_extraction: False
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
     served_dimensions: [D2, D3]
 
   rf_4B:
     size: 32
-    r_bw: 16
-    w_bw: 16
     r_cost: 0.022
     w_cost: 0.022
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fl
     served_dimensions: []
 
   sram_1KB_I:
     size: 8192
-    r_bw: 256
-    w_bw: 256
     r_cost: 4.78
     w_cost: 5.59
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 256
+        allocation: 
+          - I1, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 256
+        allocation: 
+          - I1, fh
     served_dimensions: [D1, D2, D3]
 
   sram_1KB_W:
     size: 8192
-    r_bw: 256
-    w_bw: 256
     r_cost: 4.78
     w_cost: 5.59
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 256
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 256
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2, D3]
 
   sram_1MB_A:
     size: 8388608
-    r_bw: 1024
-    w_bw: 1024
     r_cost: 208.08
     w_cost: 189.2
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1, O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_1
-        th: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2, D3]
 
   sram_1MB_W:
     size: 8388608
-    r_bw: 1024
-    w_bw: 1024
     r_cost: 208.08
     w_cost: 189.2
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 1024
+        allocation: 
+          - I2, fh
     served_dimensions: [D1, D2, D3]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 700
     w_cost: 750
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2, D3]
 
 operational_array:

--- a/zigzag/inputs/hardware/tpu_like.yaml
+++ b/zigzag/inputs/hardware/tpu_like.yaml
@@ -3,53 +3,66 @@ name: tpu_like
 memories:
   rf_128B:
     size: 1024
-    r_bw: 8
-    w_bw: 8
     r_cost: 0.095
     w_cost: 0.095
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
     operands: [I2]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
+      - name: r_port_1
+        type: read
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, tl
+      - name: w_port_1
+        type: write
+        bandwidth_min: 8
+        bandwidth_max: 8
+        allocation: 
+          - I2, fh
     served_dimensions: [] # Fully unrolled over all multipliers
 
   rf_2B:
     size: 16
-    r_bw: 16
-    w_bw: 16
     r_cost: 0.021
     w_cost: 0.021
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 16
+        bandwidth_max: 16
+        allocation: 
+          - O, fl
     served_dimensions: []
 
   sram_2MB:
     size: 16777216
-    r_bw: 2048
-    w_bw: 2048
     r_cost: 416.16
     w_cost: 378.4
     area: 0
-    r_port: 1
-    w_port: 1
-    rw_port: 0
     latency: 1
-    min_r_granularity: 64
-    min_w_granularity: 64
     operands: [I1, O]
     ports:
       - fh: w_port_1
@@ -58,29 +71,46 @@ memories:
         tl: r_port_1
         fl: w_port_1
         th: r_port_1
+    ports:
+      - name: r_port_1
+        type: read
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I1, tl
+          - O, tl
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I1, fh
+          - O, fh
+          - O, fl
     served_dimensions: [D1, D2]
 
   dram:
     size: 10000000000
-    r_bw: 64
-    w_bw: 64
     r_cost: 700
     w_cost: 750
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 64
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2]
 
 operational_array:

--- a/zigzag/inputs/mapping/tpu_like.yaml
+++ b/zigzag/inputs/mapping/tpu_like.yaml
@@ -1,9 +1,9 @@
 - name: default
   spatial_mapping:
     D1:
-      - K, 32
+      - K0, 32
     D2:
-      - C, 32
+      - C0, 32
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/mapping/tpu_like.yaml
+++ b/zigzag/inputs/mapping/tpu_like.yaml
@@ -1,9 +1,9 @@
 - name: default
   spatial_mapping:
     D1:
-      - K0, 32
+      - K, 32
     D2:
-      - C0, 32
+      - C, 32
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/mapping/data_movement.py
+++ b/zigzag/mapping/data_movement.py
@@ -61,7 +61,13 @@ class MemoryAccesses(FourWayDataMoving[int]):
 class AccessEnergy(FourWayDataMoving[float]):
     """Represents the memory access energy in four directions."""
 
-    pass  # Inherits __add__ and __mul__ from FourWayDataMoving
+    def __add__(self, other: "FourWayDataMoving[float]") -> "AccessEnergy":
+        """Element-wise addition of two AccessEnergy instances."""
+        return AccessEnergy({key: self.data[key] + other.data[key] for key in DataDirection})
+
+    def __mul__(self, scalar: float) -> "AccessEnergy":
+        """Element-wise multiplication by a scalar."""
+        return AccessEnergy({key: self.data[key] * scalar for key in DataDirection})
 
 
 class DataMoveAttr(StrEnum):

--- a/zigzag/mapping/data_movement.py
+++ b/zigzag/mapping/data_movement.py
@@ -6,6 +6,7 @@ from zigzag.hardware.architecture.memory_port import DataDirection
 
 T = TypeVar("T", bound=int | float)
 
+
 class FourWayDataMoving(Generic[T]):
     """Represents a standard four-way data moving attribute of a memory interface."""
 
@@ -50,13 +51,18 @@ class FourWayDataMoving(Generic[T]):
         """JSON-friendly representation."""
         return {key.value: self.data[key] for key in DataDirection}
 
+
 class MemoryAccesses(FourWayDataMoving[int]):
     """Represents the number of memory accesses in four directions."""
+
     pass  # Inherits __add__ and __mul__ from FourWayDataMoving
+
 
 class AccessEnergy(FourWayDataMoving[float]):
     """Represents the memory access energy in four directions."""
+
     pass  # Inherits __add__ and __mul__ from FourWayDataMoving
+
 
 class DataMoveAttr(StrEnum):
     DATA_ELEM_MOVE_COUNT = "data_elem_move_count"
@@ -68,13 +74,19 @@ class DataMoveAttr(StrEnum):
     DATA_TRANS_AMOUNT_PER_PERIOD = "data_trans_amount_per_period"
     INST_DATA_TRANS_WINDOW = "inst_data_trans_window"
 
+
 class DataMovePattern:
     """Collects the memory access pattern for each unit memory (memory holding one operand at one level)."""
 
     ATTRIBUTES = [
-        "data_elem_move_count", "data_precision", "req_mem_bw_aver", "req_mem_bw_inst",
-        "data_trans_period", "data_trans_period_count", "data_trans_amount_per_period",
-        "inst_data_trans_window"
+        "data_elem_move_count",
+        "data_precision",
+        "req_mem_bw_aver",
+        "req_mem_bw_inst",
+        "data_trans_period",
+        "data_trans_period_count",
+        "data_trans_amount_per_period",
+        "inst_data_trans_window",
     ]
 
     def __init__(self, operand: LayerOperand, mem_level: int):
@@ -105,4 +117,3 @@ class DataMovePattern:
 
     def __repr__(self):
         return f"DataMovePattern(name={self.name}, attributes={self.attributes})"
-

--- a/zigzag/mapping/data_movement.py
+++ b/zigzag/mapping/data_movement.py
@@ -90,17 +90,6 @@ class DataMoveAttr(StrEnum):
 class DataMovePattern:
     """Collects the memory access pattern for each unit memory (memory holding one operand at one level)."""
 
-    ATTRIBUTES = [
-        "data_elem_move_count",
-        "data_precision",
-        "req_mem_bw_aver",
-        "req_mem_bw_inst",
-        "data_trans_period",
-        "data_trans_period_count",
-        "data_trans_amount_per_period",
-        "inst_data_trans_window",
-    ]
-
     def __init__(self, operand: LayerOperand, mem_level: int):
         self.name = operand.name + str(mem_level)
 

--- a/zigzag/mapping/data_movement.py
+++ b/zigzag/mapping/data_movement.py
@@ -55,7 +55,13 @@ class FourWayDataMoving(Generic[T]):
 class MemoryAccesses(FourWayDataMoving[int]):
     """Represents the number of memory accesses in four directions."""
 
-    pass  # Inherits __add__ and __mul__ from FourWayDataMoving
+    def __add__(self, other: "FourWayDataMoving[int]") -> "MemoryAccesses":
+        """Element-wise addition of two AccessEnergy instances."""
+        return MemoryAccesses({key: self.data[key] + other.data[key] for key in DataDirection})
+
+    def __mul__(self, scalar: int) -> "MemoryAccesses":
+        """Element-wise multiplication by a scalar."""
+        return MemoryAccesses({key: self.data[key] * scalar for key in DataDirection})
 
 
 class AccessEnergy(FourWayDataMoving[float]):

--- a/zigzag/mapping/data_movement.py
+++ b/zigzag/mapping/data_movement.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta
+from enum import StrEnum
 from typing import Generic, TypeVar
 
 from zigzag.datatypes import LayerOperand
@@ -6,226 +6,103 @@ from zigzag.hardware.architecture.memory_port import DataDirection
 
 T = TypeVar("T", bound=int | float)
 
+class FourWayDataMoving(Generic[T]):
+    """Represents a standard four-way data moving attribute of a memory interface."""
 
-class FourWayDataMoving(Generic[T], metaclass=ABCMeta):
-    """! The standard four-way data moving attribute of a memory interface."""
-
-    def __init__(
-        self,
-        rd_out_to_low: T,
-        wr_in_by_low: T,
-        rd_out_to_high: T,
-        wr_in_by_high: T,
-    ):
-        self.rd_out_to_low = rd_out_to_low
-        self.wr_in_by_low = wr_in_by_low
-        self.rd_out_to_high = rd_out_to_high
-        self.wr_in_by_high = wr_in_by_high
-
-    @property
-    def info_list(self):
-        """! Format used in the original ZigZag version"""
-        return [
-            (self.rd_out_to_low, self.wr_in_by_low),
-            (self.rd_out_to_high, self.wr_in_by_high),
-        ]
-
-    def get_single_dir_data(self, direction: DataDirection) -> T:
-        match direction:
-            case DataDirection.RD_OUT_TO_LOW:
-                return self.rd_out_to_low
-            case DataDirection.WR_IN_BY_LOW:
-                return self.wr_in_by_low
-            case DataDirection.RD_OUT_TO_HIGH:
-                return self.rd_out_to_high
-            case DataDirection.WR_IN_BY_HIGH:
-                return self.wr_in_by_high
-
-    def update_single_dir_data(self, direction: DataDirection, new_value: T):
-        match direction:
-            case DataDirection.RD_OUT_TO_LOW:
-                self.rd_out_to_low = new_value
-            case DataDirection.WR_IN_BY_LOW:
-                self.wr_in_by_low = new_value
-            case DataDirection.RD_OUT_TO_HIGH:
-                self.rd_out_to_high = new_value
-            case DataDirection.WR_IN_BY_HIGH:
-                self.wr_in_by_high = new_value
-
-    def get_total_read_outs_to_above(self) -> T:
-        """! Return the total amount of times this memory interface is read from to the level above."""
-        return self.rd_out_to_high
-
-    def get_total_read_outs_to_below(self) -> T:
-        """! Return the total amount of times this memory interface is read from to the level below."""
-        return self.rd_out_to_low
-
-    def get_total_write_ins_from_above(self) -> T:
-        """! Return the total amount of times this memory interface is written to from the level above."""
-        return self.wr_in_by_high
-
-    def get_total_write_ins_from_below(self) -> T:
-        """! Return the total amount of times this memory interface is written to from the level below."""
-        return self.wr_in_by_low
-
-    def _add_with_type(self, other: "FourWayDataMoving[T]", return_type: type):
-        return return_type(
-            self.rd_out_to_low + other.rd_out_to_low,
-            self.wr_in_by_low + other.wr_in_by_low,
-            self.rd_out_to_high + other.rd_out_to_high,
-            self.wr_in_by_high + other.wr_in_by_high,
+    def __init__(self, data: dict[DataDirection, T] | None = None):
+        """Initialize with a dictionary containing all four DataDirection values, defaulting to zero."""
+        self.data: dict[DataDirection, T] = (
+            {direction: 0 for direction in DataDirection} if data is None else data.copy()
         )
 
-    def _mul_with_type(self, other: T, return_type: type):
-        return return_type(
-            self.rd_out_to_low * other,
-            self.wr_in_by_low * other,
-            self.rd_out_to_high * other,
-            self.wr_in_by_high * other,
-        )
+        # Ensure all required keys exist
+        missing_keys = set(DataDirection) - set(self.data)
+        if missing_keys:
+            raise ValueError(f"Missing keys in input dictionary: {missing_keys}")
+
+    def get(self, direction: DataDirection) -> T:
+        """Retrieve the value associated with a specific data direction."""
+        return self.data[direction]
+
+    def set(self, direction: DataDirection, value: T):
+        """Update the value of a specific data direction."""
+        self.data[direction] = value
 
     def __add__(self, other: "FourWayDataMoving[T]") -> "FourWayDataMoving[T]":
-        return self._add_with_type(other, type(self))
+        """Element-wise addition of two FourWayDataMoving instances."""
+        return FourWayDataMoving({key: self.data[key] + other.data[key] for key in DataDirection})  # type: ignore
+
+    def __mul__(self, scalar: T) -> "FourWayDataMoving[T]":
+        """Element-wise multiplication by a scalar."""
+        return FourWayDataMoving({key: self.data[key] * scalar for key in DataDirection})  # type: ignore
 
     def __repr__(self):
+        """Readable string representation of the class."""
         return (
-            f"4waydatamoving (rd ^: {self.rd_out_to_high}, wr v: {self.wr_in_by_high}, "
-            f"rd v: {self.rd_out_to_low}, wr ^: {self.wr_in_by_low})"
+            f"4WayDataMoving("
+            f"rd ↑: {self.data[DataDirection.RD_OUT_TO_HIGH]}, "
+            f"wr ↓: {self.data[DataDirection.WR_IN_BY_HIGH]}, "
+            f"rd ↓: {self.data[DataDirection.RD_OUT_TO_LOW]}, "
+            f"wr ↑: {self.data[DataDirection.WR_IN_BY_LOW]})"
         )
 
     def __jsonrepr__(self):
-        return {
-            "rd ^": self.rd_out_to_high,
-            "wr v": self.wr_in_by_high,
-            "rd v": self.rd_out_to_low,
-            "wr ^": self.wr_in_by_low,
-        }
-
+        """JSON-friendly representation."""
+        return {key.value: self.data[key] for key in DataDirection}
 
 class MemoryAccesses(FourWayDataMoving[int]):
-    """Represents the number of memory accesses in four directions"""
-
-    def __add__(self, other: "MemoryAccesses"):
-        return self._add_with_type(other, type(self))
-
-    def __mul__(self, other: int):
-        return self._mul_with_type(other, type(self))
-
+    """Represents the number of memory accesses in four directions."""
+    pass  # Inherits __add__ and __mul__ from FourWayDataMoving
 
 class AccessEnergy(FourWayDataMoving[float]):
-    """Represents the memory access energy in four directions"""
+    """Represents the memory access energy in four directions."""
+    pass  # Inherits __add__ and __mul__ from FourWayDataMoving
 
-    def __add__(self, other: "AccessEnergy"):
-        return self._add_with_type(other, type(self))
-
-    def __mul__(self, other: float):
-        return self._mul_with_type(other, type(self))
-
+class DataMoveAttr(StrEnum):
+    DATA_ELEM_MOVE_COUNT = "data_elem_move_count"
+    DATA_PRECISION = "data_precision"
+    REQ_MEM_BW_AVER = "req_mem_bw_aver"
+    REQ_MEM_BW_INST = "req_mem_bw_inst"
+    DATA_TRANS_PERIOD = "data_trans_period"
+    DATA_TRANS_PERIOD_COUNT = "data_trans_period_count"
+    DATA_TRANS_AMOUNT_PER_PERIOD = "data_trans_amount_per_period"
+    INST_DATA_TRANS_WINDOW = "inst_data_trans_window"
 
 class DataMovePattern:
-    """! Collect the memory access pattern for each unit memory (memory that only hold one operand at one level)."""
+    """Collects the memory access pattern for each unit memory (memory holding one operand at one level)."""
+
+    ATTRIBUTES = [
+        "data_elem_move_count", "data_precision", "req_mem_bw_aver", "req_mem_bw_inst",
+        "data_trans_period", "data_trans_period_count", "data_trans_amount_per_period",
+        "inst_data_trans_window"
+    ]
 
     def __init__(self, operand: LayerOperand, mem_level: int):
         self.name = operand.name + str(mem_level)
-        self.data_elem_move_count = MemoryAccesses(0, 0, 0, 0)  # elements
-        self.data_precision = MemoryAccesses(0, 0, 0, 0)  # bits/element
-        self.req_mem_bw_aver = MemoryAccesses(0, 0, 0, 0)  # bits/cycle
-        self.req_mem_bw_inst = MemoryAccesses(0, 0, 0, 0)  # bits/cycle
-        self.data_trans_period = MemoryAccesses(0, 0, 0, 0)  # cycles
-        self.data_trans_period_count = MemoryAccesses(0, 0, 0, 0)  # periods
-        self.data_trans_amount_per_period = MemoryAccesses(0, 0, 0, 0)  # elements
-        self.inst_data_trans_window = MemoryAccesses(0, 0, 0, 0)  # cycles
 
-    def set_data_elem_move_count(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        self.data_elem_move_count = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
+        # Use a dictionary to store all attributes as FourWayDataMoving instances
+        self.attributes: dict[DataMoveAttr, FourWayDataMoving[int]] = {
+            attr: FourWayDataMoving() for attr in DataMoveAttr
+        }
 
-    def set_data_precision(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        self.data_precision = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
+    def set_attribute(self, attr: DataMoveAttr, values: dict[DataDirection, int]):
+        """Set a given attribute using a dictionary of DataDirection values."""
+        if attr not in DataMoveAttr:
+            raise ValueError(f"Invalid attribute name: {attr}")
+        self.attributes[attr] = FourWayDataMoving(values)
 
-    def set_req_mem_bw_aver(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        self.req_mem_bw_aver = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
-
-    def set_req_mem_bw_inst(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        self.req_mem_bw_inst = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
-
-    def set_data_trans_period(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        # data_trans_period: every how many cycle, the memory link need to be activated for a certain duration
-        self.data_trans_period = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
-
-    def set_data_trans_period_count(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        # data_trans_period_count: to finish all the for-loop computation, how many such ideal_period is required
-        self.data_trans_period_count = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
-
-    def set_data_trans_amount_per_period(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        # data_trans_amount_per_period: data amount that being transferred for each single period
-        self.data_trans_amount_per_period = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
-
-    def set_inst_data_trans_window(
-        self,
-        rd_out_to_low: int,
-        wr_in_by_low: int,
-        rd_out_to_high: int,
-        wr_in_by_high: int,
-    ):
-        # inst_data_trans_window: the allowed memory updating window, assuming the served memory level
-        # is non-double buffered (thus need to avoid the data overwriting issue
-        self.inst_data_trans_window = MemoryAccesses(rd_out_to_low, wr_in_by_low, rd_out_to_high, wr_in_by_high)
+    def get_attribute(self, attr: DataMoveAttr) -> FourWayDataMoving[int]:
+        """Retrieve a specific attribute."""
+        return self.attributes[attr]
 
     def update_single_dir_data(self, direction: DataDirection, new_value: int):
-        """! update a single direction value for all data move attributes"""
-        self.data_elem_move_count.update_single_dir_data(direction, new_value)
-        self.data_precision.update_single_dir_data(direction, new_value)
-        self.req_mem_bw_aver.update_single_dir_data(direction, new_value)
-        self.req_mem_bw_inst.update_single_dir_data(direction, new_value)
-        self.data_trans_period.update_single_dir_data(direction, new_value)
-        self.data_trans_period_count.update_single_dir_data(direction, new_value)
-        self.data_trans_amount_per_period.update_single_dir_data(direction, new_value)
-        self.inst_data_trans_window.update_single_dir_data(direction, new_value)
+        """Update a single direction value across all attributes."""
+        for attr in self.attributes.values():
+            attr.set(direction, new_value)
 
     def __str__(self):
         return self.name
 
     def __repr__(self):
-        return str(self)
+        return f"DataMovePattern(name={self.name}, attributes={self.attributes})"
+

--- a/zigzag/parser/accelerator_factory.py
+++ b/zigzag/parser/accelerator_factory.py
@@ -12,7 +12,7 @@ from zigzag.hardware.architecture.imc_array import ImcArray
 from zigzag.hardware.architecture.memory_hierarchy import MemoryHierarchy
 from zigzag.hardware.architecture.memory_instance import MemoryInstance
 from zigzag.hardware.architecture.memory_level import ServedMemDimensions
-from zigzag.hardware.architecture.memory_port import DataDirection, MemoryPort, PortAllocation, MemoryPortType
+from zigzag.hardware.architecture.memory_port import DataDirection, MemoryPort, MemoryPortType, PortAllocation
 from zigzag.hardware.architecture.operational_array import (
     MultiplierArray,
     OperationalArrayABC,
@@ -163,7 +163,6 @@ class MemoryFactory:
             port = MemoryPort(port_name, port_type, port_bw_min, port_bw_max)
             memory_ports.append(port)
         return tuple(memory_ports)
-        
 
     def create_memory_instance(self) -> MemoryInstance:
         memory_ports = self.create_memory_ports()
@@ -203,7 +202,7 @@ class MemoryFactory:
         """The order of the port allocations matches the order of the MemoryOperands.
         # TODO support empty allocation -> return default configuration
         """
-        allocation_data: dict[MemoryOperand, dict[DataDirection, str]] 
+        allocation_data: dict[MemoryOperand, dict[DataDirection, str]]
         allocation_data = {MemoryOperand(mem_op_str): {} for mem_op_str in self.data["operands"]}
         for port in self.data["ports"]:
             name = port["name"]

--- a/zigzag/parser/accelerator_factory.py
+++ b/zigzag/parser/accelerator_factory.py
@@ -207,9 +207,9 @@ class MemoryFactory:
         for port in self.data["ports"]:
             name = port["name"]
             for alloc in port["allocation"]:
-                operand, dir = alloc.split(", ")
+                operand, data_dir = alloc.split(", ")
                 operand = MemoryOperand(operand)
-                direction = DataDirection(self.translate_to_data_direction(dir))
+                direction = DataDirection(self.translate_to_data_direction(data_dir))
                 allocation_data[operand][direction] = name
         return PortAllocation(allocation_data)
 

--- a/zigzag/parser/accelerator_validator.py
+++ b/zigzag/parser/accelerator_validator.py
@@ -229,7 +229,7 @@ class AcceleratorValidator:
         # Direction of ports is valid
         for port in mem_data["ports"]:
             for allocation in port["allocation"]:
-                operand, direction = allocation.split(", ")
+                _, direction = allocation.split(", ")
                 if direction in ["fh", "fl"] and port["type"] == "read":
                     self.invalidate(f"Read port given for write direction in {mem_name}")
                 if direction in ["th", "tl"] and port["type"] == "write":

--- a/zigzag/parser/accelerator_validator.py
+++ b/zigzag/parser/accelerator_validator.py
@@ -213,14 +213,6 @@ class AcceleratorValidator:
             if mem_data["area"] is None:
                 self.invalidate(f"`area` of {mem_name} is missing, and is not automatically extracted using CACTI.")
 
-        # Number of port allocations is consistent with memory operands
-        # nb_operands = len(mem_data["operands"])
-        # nb_ports = len(mem_data["ports"])
-        # if nb_ports != nb_operands:
-        #     self.invalidate(
-        #         f"Number of memory ports ({nb_ports}) does not equal number of operands ({nb_operands}) for {mem_name}"
-        #     )
-
         # No unexpected served dimensions
         for served_dimension in mem_data["served_dimensions"]:
             if served_dimension not in expected_oa_dims:

--- a/zigzag/parser/accelerator_validator.py
+++ b/zigzag/parser/accelerator_validator.py
@@ -62,7 +62,11 @@ class AcceleratorValidator:
                             "type": "dict",
                             "schema": {
                                 "name": {"type": "string", "regex": PORT_REGEX, "required": True},
-                                "type": {"type": "string", "allowed": ["read", "write", "read_write"], "required": True},
+                                "type": {
+                                    "type": "string",
+                                    "allowed": ["read", "write", "read_write"],
+                                    "required": True,
+                                },
                                 "bandwidth_min": {"type": "integer", "required": True},
                                 "bandwidth_max": {"type": "integer", "required": True},
                                 "allocation": {

--- a/zigzag/parser/accelerator_validator.py
+++ b/zigzag/parser/accelerator_validator.py
@@ -14,6 +14,7 @@ class AcceleratorValidator:
     OPERAND_REGEX = r"^I[12]$|^O$"
     DIMENSION_REGEX = r"^D\d$"
     PORT_REGEX = r"^[r]?[w]?_port_\d+$"
+    ALLOCATION_REGEX = r"^(I[12]|O), (fh|tl|fl|th)$"
 
     SCHEMA = {
         "name": {"type": "string", "required": True},
@@ -24,8 +25,6 @@ class AcceleratorValidator:
                 "type": "dict",
                 "schema": {
                     "size": {"type": "integer", "required": True},
-                    "r_bw": {"type": "integer", "required": True},
-                    "w_bw": {"type": "integer", "required": True},
                     "r_cost": {
                         "type": "float",
                         "required": False,
@@ -44,22 +43,7 @@ class AcceleratorValidator:
                         "nullable": True,
                         "default": None,
                     },
-                    "r_port": {"type": "integer", "required": True},
-                    "w_port": {"type": "integer", "required": True},
-                    "rw_port": {"type": "integer", "required": True},
                     "latency": {"type": "integer", "required": True},
-                    "min_r_granularity": {
-                        "type": "integer",
-                        "required": False,
-                        "nullable": True,
-                        "default": None,
-                    },
-                    "min_w_granularity": {
-                        "type": "integer",
-                        "required": False,
-                        "nullable": True,
-                        "default": None,
-                    },
                     "mem_type": {
                         "type": "string",
                         "required": False,
@@ -77,25 +61,14 @@ class AcceleratorValidator:
                         "schema": {
                             "type": "dict",
                             "schema": {
-                                "fh": {
-                                    "type": "string",
-                                    "required": False,
-                                    "regex": PORT_REGEX,
-                                },
-                                "tl": {
-                                    "type": "string",
-                                    "required": False,
-                                    "regex": PORT_REGEX,
-                                },
-                                "fl": {
-                                    "type": "string",
-                                    "required": False,
-                                    "regex": PORT_REGEX,
-                                },
-                                "th": {
-                                    "type": "string",
-                                    "required": False,
-                                    "regex": PORT_REGEX,
+                                "name": {"type": "string", "regex": PORT_REGEX, "required": True},
+                                "type": {"type": "string", "allowed": ["read", "write", "read_write"], "required": True},
+                                "bandwidth_min": {"type": "integer", "required": True},
+                                "bandwidth_max": {"type": "integer", "required": True},
+                                "allocation": {
+                                    "type": "list",
+                                    "required": True,
+                                    "schema": {"type": "string", "regex": ALLOCATION_REGEX},
                                 },
                             },
                         },
@@ -237,57 +210,31 @@ class AcceleratorValidator:
                 self.invalidate(f"`area` of {mem_name} is missing, and is not automatically extracted using CACTI.")
 
         # Number of port allocations is consistent with memory operands
-        nb_operands = len(mem_data["operands"])
-        nb_ports = len(mem_data["ports"])
-        if nb_ports != nb_operands:
-            self.invalidate(
-                f"Number of memory ports ({nb_ports}) does not equal number of operands ({nb_operands}) for {mem_name}"
-            )
+        # nb_operands = len(mem_data["operands"])
+        # nb_ports = len(mem_data["ports"])
+        # if nb_ports != nb_operands:
+        #     self.invalidate(
+        #         f"Number of memory ports ({nb_ports}) does not equal number of operands ({nb_operands}) for {mem_name}"
+        #     )
 
         # No unexpected served dimensions
         for served_dimension in mem_data["served_dimensions"]:
             if served_dimension not in expected_oa_dims:
                 self.invalidate(f"Invalid served dimension {served_dimension} in memory {mem_name}")
 
-        # Number of allocated ports per type equals given number of ports
-        port_data: list[dict[str, str]] = mem_data["ports"]
-        r_ports: set[str] = set()
-        w_ports: set[str] = set()
-        rw_ports: set[str] = set()
-        for port_dict in port_data:
-            for port_name in port_dict.values():
-                match port_name[0:2]:
-                    case "r_":
-                        r_ports.add(port_name)
-                    case "w_":
-                        w_ports.add(port_name)
-                    case "rw":
-                        rw_ports.add(port_name)
-                    case _:
-                        raise ValueError("Invalid port name")
-        if len(r_ports) != mem_data["r_port"]:
-            self.invalidate(
-                f"Number of given read ports ({mem_data['r_port']}) does not equal number of allocated read ports "
-                f"({len(r_ports)}) for {mem_name}"
-            )
-        if len(w_ports) != mem_data["w_port"]:
-            self.invalidate(
-                f"Number of given write ports ({mem_data['w_port']}) does not equal number of allocated write ports "
-                f"({len(w_ports)}) for {mem_name}"
-            )
-        if len(rw_ports) != mem_data["rw_port"]:
-            self.invalidate(
-                f"Number of given read/write ports ({mem_data['rw_port']}) does not equal number of allocated "
-                f"read/write ports ({len(rw_ports)}) for {mem_name}"
-            )
-
         # Direction of ports is valid
-        for port_dict in port_data:
-            for direction, port_name in port_dict.items():
-                if (direction == "fh" or direction == "fl") and (port_name.startswith("r_")):
+        for port in mem_data["ports"]:
+            for allocation in port["allocation"]:
+                operand, direction = allocation.split(", ")
+                if direction in ["fh", "fl"] and port["type"] == "read":
                     self.invalidate(f"Read port given for write direction in {mem_name}")
-                if (direction == "th" or direction == "tl") and (port_name.startswith("w_")):
+                if direction in ["th", "tl"] and port["type"] == "write":
                     self.invalidate(f"Write port given for read direction in {mem_name}")
+
+        # Bandwidths of ports is valid
+        for port in mem_data["ports"]:
+            if port["bandwidth_min"] > port["bandwidth_max"]:
+                self.invalidate(f"Minimum bandwidth is greater than maximum bandwidth in {mem_name}")
 
     def validate_cells_imc(self):
         if "cells" not in self.data["memories"]:
@@ -310,7 +257,6 @@ class AcceleratorValidator:
         # For both IMC and non-IMC:
         oa_dims: list[str] = multiplier_data["dimensions"]
         if len(oa_dims) != len(multiplier_data["sizes"]):
-            # TODO Alternatively, you can force the user to not
             self.invalidate("Core dimensions and sizes do not match.")
 
         if self.is_imc:

--- a/zigzag/parser/mapping_validator.py
+++ b/zigzag/parser/mapping_validator.py
@@ -17,22 +17,22 @@ class MappingValidator:
             "schema": {
                 "D1": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
                 "D2": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
                 "D3": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
                 "D4": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
             },

--- a/zigzag/stages/mapping/spatial_mapping_generation.py
+++ b/zigzag/stages/mapping/spatial_mapping_generation.py
@@ -17,6 +17,7 @@ from zigzag.hardware.architecture.accelerator import Accelerator
 from zigzag.hardware.architecture.memory_hierarchy import MemoryHierarchy
 from zigzag.hardware.architecture.memory_instance import MemoryInstance
 from zigzag.hardware.architecture.memory_level import ServedMemDimensions
+from zigzag.mapping.data_movement import DataDirection
 from zigzag.mapping.spatial_mapping import (
     MappingSingleOADim,
     SpatialMapping,
@@ -197,7 +198,8 @@ class SpatialMappingGeneratorStage(Stage):
             for mem_op in mem_level.operands:
                 layer_op = self.layer.memory_operand_links.mem_to_layer_op(mem_op)
                 # Either write BW (to write outputs away) or read BW (to read inputs)
-                mem_bandwidth = mem_level.write_bw if layer_op.is_output() else mem_level.read_bw
+                data_dir = DataDirection.WR_IN_BY_LOW if layer_op.is_output() else DataDirection.RD_OUT_TO_LOW
+                mem_bandwidth = mem_level.get_max_bandwidth(mem_op, data_dir)
                 # Bit precision of layer operand
                 precision = self.layer.operand_precision[layer_op]
                 irrelevant_dimensions = self.layer.get_operand_irrelevant_layer_dims(layer_op)

--- a/zigzag/visualization/results/plot_cme.py
+++ b/zigzag/visualization/results/plot_cme.py
@@ -68,7 +68,7 @@ def get_energy_array(
     mem_energy_array = np.array(
         [
             [
-                [[access_energy[cme_idx][op][mem].get(dir) for dir in DataDirection] for op in all_ops]
+                [[access_energy[cme_idx][op][mem].get(data_dir) for data_dir in DataDirection] for op in all_ops]
                 for mem in all_mems
             ]
             for cme_idx in range(len(cmes))
@@ -110,7 +110,7 @@ def bar_plot_cost_model_evaluations_breakdown(cmes: list[CostModelEvaluationABC]
     groups = [f"{cme.layer.id}: {shorten_onnx_layer_name(cme.layer.name)}" for cme in cmes_to_plot]
     bars_energy = ["MAC"] + [mem.name for mem in all_mems]
     sections_energy = [op.name for op in all_ops]
-    subsections_energy = [str(dir) for dir in DataDirection]
+    subsections_energy = [str(data_dir) for data_dir in DataDirection]
     sections_latency = [
         "Ideal computation",
         "Spatial stall",

--- a/zigzag/visualization/results/plot_cme.py
+++ b/zigzag/visualization/results/plot_cme.py
@@ -54,7 +54,7 @@ def get_energy_array(
 
     mem_hierarchy = cmes[0].accelerator.memory_hierarchy
     access_energy: dict[int, defaultdict[LayerOperand, defaultdict[MemoryInstance, AccessEnergy]]] = {
-        idx: defaultdict(lambda: defaultdict(lambda: AccessEnergy(0, 0, 0, 0))) for idx in range(len(cmes))
+        idx: defaultdict(lambda: defaultdict(lambda: AccessEnergy())) for idx in range(len(cmes))
     }
 
     for cme_idx, cme in enumerate(cmes):
@@ -68,7 +68,7 @@ def get_energy_array(
     mem_energy_array = np.array(
         [
             [
-                [[access_energy[cme_idx][op][mem].get_single_dir_data(dir) for dir in DataDirection] for op in all_ops]
+                [[access_energy[cme_idx][op][mem].get(dir) for dir in DataDirection] for op in all_ops]
                 for mem in all_mems
             ]
             for cme_idx in range(len(cmes))

--- a/zigzag/visualization/results/plot_cme.py
+++ b/zigzag/visualization/results/plot_cme.py
@@ -54,7 +54,7 @@ def get_energy_array(
 
     mem_hierarchy = cmes[0].accelerator.memory_hierarchy
     access_energy: dict[int, defaultdict[LayerOperand, defaultdict[MemoryInstance, AccessEnergy]]] = {
-        idx: defaultdict(lambda: defaultdict(lambda: AccessEnergy())) for idx in range(len(cmes))
+        idx: defaultdict(lambda: defaultdict(AccessEnergy)) for idx in range(len(cmes))
     }
 
     for cme_idx, cme in enumerate(cmes):


### PR DESCRIPTION
This PR enables different bandwidths per MemoryPort.

This also moves the min_r_granularity and min_w_granularity which represented the minimum bits read per cycle (in case the requirements are lower than the max bandwidth) and scaled the energy cost per transfer accordingly. This field is now defined as the min bandwidth per port.

Lastly, all inputs/hardware accelerator architectures were updated to the new format.