### PR TITLE
Add extended regex for spatial and temporal mapping

### DIFF
--- a/zigzag/parser/mapping_validator.py
+++ b/zigzag/parser/mapping_validator.py
@@ -17,22 +17,22 @@ class MappingValidator:
             "schema": {
                 "D1": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
                 "D2": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
                 "D3": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
                 "D4": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+, [0-9]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*, \d+$"},
                     "required": False,
                 },
             },
@@ -53,22 +53,22 @@ class MappingValidator:
             "schema": {
                 "D1": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*"},
                     "required": False,
                 },
                 "D2": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*"},
                     "required": False,
                 },
                 "D3": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*"},
                     "required": False,
                 },
                 "D4": {
                     "type": "list",
-                    "schema": {"type": "string", "regex": r"^[A-Z]+$"},
+                    "schema": {"type": "string", "regex": r"^[A-Z]+\d*"},
                     "required": False,
                 },
             },


### PR DESCRIPTION
This extends the spatial and temporal mapping to be expandable with e.g., D0, D1, ..., D32

@asyms I'm not sure how to add a test for this... It would be nice if the gemm_like accelerator could be added to main at some point?
