### PR TITLE
Add even mapping restriction

### DIFF
--- a/zigzag/api.py
+++ b/zigzag/api.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from onnx import ModelProto
 
 from zigzag.cost_model.cost_model import CostModelEvaluationABC
+from zigzag.mapping.temporal_mapping import TemporalMappingType
 from zigzag.stages.evaluation.cost_model_evaluation import CostModelStage
 from zigzag.stages.exploit_data_locality_stages import (
     ExploitInterLayerDataLocalityStage,
@@ -30,6 +31,7 @@ def get_hardware_performance_zigzag(
     mapping: str,
     *,
     temporal_mapping_search_engine: Literal["loma"] | Literal["salsa"] = "loma",
+    temporal_mapping_type: Literal["uneven"] | Literal["even"] = "uneven",
     opt: str = "latency",
     dump_folder: str = f"outputs/{datetime.now()}",
     pickle_filename: str | None = None,
@@ -87,6 +89,7 @@ def get_hardware_performance_zigzag(
     do_mix_spatial_mapping_generation = in_memory_compute or enable_mix_spatial_mapping
     # Select temporal mapping engine based on the function input
     temporal_mapping_engine = SalsaStage if temporal_mapping_search_engine == "salsa" else TemporalMappingGeneratorStage
+    tm_type = TemporalMappingType(temporal_mapping_type)
 
     stages = [
         # Parse the ONNX Model into the workload
@@ -139,6 +142,7 @@ def get_hardware_performance_zigzag(
         # smaller than the memory read bw, # take into account only one-time access cost (assume the data can stay at
         # the output pins of the memory as long as it is needed).
         access_same_data_considered_as_no_access=True,
+        temporal_mapping_type=tm_type,
     )
 
     # Launch the MainStage

--- a/zigzag/mapping/mapping.py
+++ b/zigzag/mapping/mapping.py
@@ -7,7 +7,7 @@ from zigzag.hardware.architecture.memory_port import DataDirection
 from zigzag.mapping.data_movement import DataMovePattern
 from zigzag.mapping.mapping_assist_funcs import SpatialMappingPerMemLvl
 from zigzag.mapping.spatial_mapping_internal import SpatialMappingInternal
-from zigzag.mapping.temporal_mapping import TemporalMapping, TemporalMappingDict
+from zigzag.mapping.temporal_mapping import TemporalMapping
 from zigzag.workload.layer_node import LayerNode
 
 
@@ -22,7 +22,7 @@ class Mapping:
         self,
         accelerator: Accelerator,
         spatial_mapping: SpatialMappingPerMemLvl | SpatialMappingInternal,
-        temporal_mapping: TemporalMappingDict | TemporalMapping,
+        temporal_mapping: TemporalMapping,
         layer_node: LayerNode,
         access_same_data_considered_as_no_access: bool = False,
     ):
@@ -32,10 +32,7 @@ class Mapping:
             self.spatial_mapping = spatial_mapping
         else:
             self.spatial_mapping = SpatialMappingInternal(spatial_mapping, layer_node)
-        if isinstance(temporal_mapping, TemporalMapping):
-            self.temporal_mapping = temporal_mapping
-        else:
-            self.temporal_mapping = TemporalMapping(temporal_mapping, layer_node)
+        self.temporal_mapping = temporal_mapping
         self.layer_node = layer_node
         self.operand_list = layer_node.layer_operands
         self.access_same_data_considered_as_no_access = access_same_data_considered_as_no_access

--- a/zigzag/mapping/temporal_mapping.py
+++ b/zigzag/mapping/temporal_mapping.py
@@ -1,4 +1,5 @@
 import math
+from enum import StrEnum
 from typing import TypeAlias
 
 from zigzag.datatypes import LayerDim, LayerOperand, UnrollFactor
@@ -6,6 +7,13 @@ from zigzag.utils import json_repr_handler, pickle_deepcopy
 from zigzag.workload.layer_node import LayerNode
 
 TemporalMappingDict: TypeAlias = dict[LayerOperand, list[list[tuple[LayerDim, UnrollFactor]]]]
+
+
+class TemporalMappingType(StrEnum):
+    """! Enum class to represent the type of temporal mapping. This is even or uneven."""
+
+    EVEN = "even"
+    UNEVEN = "uneven"
 
 
 class TemporalMapping:

--- a/zigzag/mapping/temporal_mapping.py
+++ b/zigzag/mapping/temporal_mapping.py
@@ -19,10 +19,13 @@ class TemporalMappingType(StrEnum):
 class TemporalMapping:
     """! Class that collect all the info related to temporal mapping."""
 
-    def __init__(self, temporal_mapping_dict: TemporalMappingDict, layer_node: LayerNode):
+    def __init__(
+        self, temporal_mapping_dict: TemporalMappingDict, layer_node: LayerNode, mapping_type: TemporalMappingType
+    ):
         self.mapping_dic_origin = temporal_mapping_dict
         self.layer_node = layer_node
         self.operand_list = layer_node.layer_operands
+        self.type = mapping_type
 
         # Extract memory hierarchy level count for each operand from temporal mapping definition
         self.mem_level = {op: len(tmap) for (op, tmap) in temporal_mapping_dict.items()}

--- a/zigzag/opt/loma/engine.py
+++ b/zigzag/opt/loma/engine.py
@@ -101,10 +101,9 @@ class LomaEngine:
                 self.accelerator,
                 self.layer,
                 self.spatial_mapping,
-                ordering,
+                ordering,  # type: ignore
                 self.mapping_type,
             )
-type: ignore
             # using try catch here because in the depth-first mode the highest level might not be big enough
             try:
                 temporal_mapping = allocator.run()  # allocate this ordering to the memories

--- a/zigzag/opt/loma/engine.py
+++ b/zigzag/opt/loma/engine.py
@@ -97,7 +97,14 @@ class LomaEngine:
 
         yielded = False
         for ordering in self.ordering_generator():
-            allocator = MemoryAllocator(self.accelerator, self.layer, self.spatial_mapping, ordering, self.mapping_type)  # type: ignore
+            allocator = MemoryAllocator(  # type: ignore
+                self.accelerator,
+                self.layer,
+                self.spatial_mapping,
+                ordering,
+                self.mapping_type,
+            )
+type: ignore
             # using try catch here because in the depth-first mode the highest level might not be big enough
             try:
                 temporal_mapping = allocator.run()  # allocate this ordering to the memories

--- a/zigzag/opt/loma/engine.py
+++ b/zigzag/opt/loma/engine.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 from zigzag.datatypes import LayerDim, UnrollFactor
 from zigzag.hardware.architecture.accelerator import Accelerator
 from zigzag.mapping.spatial_mapping_internal import SpatialMappingInternal
-from zigzag.mapping.temporal_mapping import TemporalMapping
+from zigzag.mapping.temporal_mapping import TemporalMapping, TemporalMappingType
 from zigzag.opt.loma.memory_allocator import (
     MemoryAllocator,
     MemoryHierarchyTooSmallException,
@@ -50,6 +50,7 @@ class LomaEngine:
         accelerator: Accelerator,
         layer: LayerNode,
         spatial_mapping: SpatialMappingInternal,
+        mapping_type: TemporalMappingType,
         loma_lpf_limit: int | None = None,
         **kwargs: Any,
     ):
@@ -69,6 +70,7 @@ class LomaEngine:
         self.spatial_mapping = spatial_mapping
         self.constraints = []
         self.has_constraints = False
+        self.mapping_type = mapping_type
 
         # Extract the memory hierarchy from the accelerator
         # TODO: Take into account that data might be stored in lower level,
@@ -95,7 +97,7 @@ class LomaEngine:
 
         yielded = False
         for ordering in self.ordering_generator():
-            allocator = MemoryAllocator(self.accelerator, self.layer, self.spatial_mapping, ordering)  # type: ignore
+            allocator = MemoryAllocator(self.accelerator, self.layer, self.spatial_mapping, ordering, self.mapping_type)  # type: ignore
             # using try catch here because in the depth-first mode the highest level might not be big enough
             try:
                 temporal_mapping = allocator.run()  # allocate this ordering to the memories

--- a/zigzag/opt/loma/loop.py
+++ b/zigzag/opt/loma/loop.py
@@ -15,3 +15,8 @@ class Loop:
 
     def __repr__(self):
         return str(self)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Loop):
+            return False
+        return self.layer_dim == other.layer_dim and self.size == other.size and self.loop_type == other.loop_type

--- a/zigzag/opt/loma/memory_allocator.py
+++ b/zigzag/opt/loma/memory_allocator.py
@@ -37,7 +37,7 @@ class MemoryAllocator:
         layer: LayerNode,
         spatial_mapping: SpatialMappingInternal,
         ordering: list[tuple[LayerDim, UnrollFactorInt]],
-        mapping_type: TemporalMappingType = TemporalMappingType.EVEN,
+        mapping_type: TemporalMappingType,
     ):
         self.accelerator = accelerator
         self.layer = layer
@@ -93,7 +93,7 @@ class MemoryAllocator:
 
         # After all the nodes have been allocated, we can create the TemporalMapping
         # object from the dictionary we have built
-        temporal_mapping = TemporalMapping(self.temporal_mapping_dict, self.layer)
+        temporal_mapping = TemporalMapping(self.temporal_mapping_dict, self.layer, self.mapping_type)
         return temporal_mapping
 
     def allocate_node(self, node: MemoryLevel, top_levels: dict[MemoryOperand, MemoryLevel]):

--- a/zigzag/opt/loma/memory_allocator.py
+++ b/zigzag/opt/loma/memory_allocator.py
@@ -14,7 +14,7 @@ from zigzag.datatypes import (
 from zigzag.hardware.architecture.accelerator import Accelerator
 from zigzag.hardware.architecture.memory_level import MemoryLevel
 from zigzag.mapping.spatial_mapping_internal import SpatialMappingInternal
-from zigzag.mapping.temporal_mapping import TemporalMapping, TemporalMappingDict
+from zigzag.mapping.temporal_mapping import TemporalMapping, TemporalMappingDict, TemporalMappingType
 from zigzag.opt.loma.loop import Loop
 from zigzag.workload.layer_attributes import LayerDimSizes
 from zigzag.workload.layer_node import LayerNode
@@ -37,6 +37,7 @@ class MemoryAllocator:
         layer: LayerNode,
         spatial_mapping: SpatialMappingInternal,
         ordering: list[tuple[LayerDim, UnrollFactorInt]],
+        mapping_type: TemporalMappingType = TemporalMappingType.EVEN,
     ):
         self.accelerator = accelerator
         self.layer = layer
@@ -56,7 +57,8 @@ class MemoryAllocator:
         self.precision[Constants.FINAL_OUTPUT_MEM_OP] = self.layer.operand_precision.final_output_precision
 
         # Initialize the unallocated loops with the ordering for each operand
-        self.unallocated = {mem_op: [Loop(dim, size) for (dim, size) in self.ordering] for mem_op in self.mem_ops}
+        all_temporal_loops = [Loop(dim, size) for (dim, size) in self.ordering]
+        self.unallocated = {mem_op: [loop for loop in all_temporal_loops] for mem_op in self.mem_ops}
 
         # Initialize the allocated loops with the spatial mapping at the operand level for each operand
         self.allocated: dict[MemoryOperand, list[Loop]] = {}
@@ -73,6 +75,8 @@ class MemoryAllocator:
         # It is a dictionary with keys the different layer operands and values a list of lists.
         # The sublists represent the memory levels for that operand and contain the loops allocated to that level.
         self.temporal_mapping_dict: TemporalMappingDict = {layer_op: [] for layer_op in self.layer_ops}
+
+        self.mapping_type = mapping_type
 
     def run(self):
         """! Run the memory allocation process.
@@ -297,7 +301,30 @@ class MemoryAllocator:
                         unrolling."""
                     )
                 continue
-            if accesses_comb <= best_accesses:
+            if (accesses_comb <= best_accesses) and self.is_valid_idx_combination_for_mapping_type(
+                current_loop_idxs, mem_ops
+            ):
                 best_accesses = accesses_comb
                 best_loop_idxs = current_loop_idxs
         return best_loop_idxs
+
+    def is_valid_idx_combination_for_mapping_type(self, idx_comb: list[int], mem_ops: list[MemoryOperand]) -> bool:
+        """! Check if the idx_comb is a valid combination for the mapping_type."""
+        if self.mapping_type == TemporalMappingType.UNEVEN:
+            return True
+        elif self.mapping_type == TemporalMappingType.EVEN:
+            return self.is_valid_idx_combination_for_even_mapping_type(idx_comb, mem_ops)
+        else:
+            raise NotImplementedError(f"Mapping type {self.mapping_type} validity checks not implemented.")
+
+    def is_valid_idx_combination_for_even_mapping_type(self, idx_comb: list[int], mem_ops: list[MemoryOperand]):
+        """! Check if the idx_comb is a valid combination for the EVEN mapping type."""
+        to_be_allocated_loops = [
+            loop for mem_op, idx in zip(mem_ops, idx_comb) for loop in self.unallocated[mem_op][idx:]
+        ]
+        to_remain_unallocated_loops = [
+            loop for mem_op, idx in zip(mem_ops, idx_comb) for loop in self.unallocated[mem_op][:idx]
+        ]
+        if any([loop in to_remain_unallocated_loops for loop in to_be_allocated_loops]):
+            return False
+        return True

--- a/zigzag/opt/salsa/engine.py
+++ b/zigzag/opt/salsa/engine.py
@@ -39,6 +39,7 @@ from sympy.ntheory import factorint  # type: ignore
 from zigzag.datatypes import LayerDim
 from zigzag.hardware.architecture.accelerator import Accelerator
 from zigzag.mapping.spatial_mapping_internal import SpatialMappingInternal
+from zigzag.mapping.temporal_mapping import TemporalMappingType
 from zigzag.opt.salsa.state import SalsaState
 from zigzag.workload.layer_node import LayerNode
 
@@ -64,6 +65,7 @@ class SalsaEngine:
         accelerator: Accelerator,
         layer: LayerNode,
         spatial_mapping: SpatialMappingInternal,
+        mapping_type: TemporalMappingType,
         **kwargs: Any,
     ):
         """! Initialize the engine with the given:
@@ -79,6 +81,7 @@ class SalsaEngine:
         self.accelerator = accelerator
         self.layer = layer
         self.spatial_mapping = spatial_mapping
+        self.mapping_type = mapping_type
 
         # Algorithm related inputs
         self.iteration_number = kwargs.get("salsa_iteration_number", 1000)
@@ -109,6 +112,7 @@ class SalsaEngine:
             self.spatial_mapping,
             start_ordering,
             self.opt_criterion_name,
+            self.mapping_type,
         )
         current_state = SalsaState(
             self.accelerator,
@@ -116,6 +120,7 @@ class SalsaEngine:
             self.spatial_mapping,
             start_ordering,
             self.opt_criterion_name,
+            self.mapping_type,
         )
         next_state = SalsaState(
             self.accelerator,
@@ -123,6 +128,7 @@ class SalsaEngine:
             self.spatial_mapping,
             start_ordering,
             self.opt_criterion_name,
+            self.mapping_type,
         )
 
         for it in range(self.iteration_number):

--- a/zigzag/opt/salsa/state.py
+++ b/zigzag/opt/salsa/state.py
@@ -32,6 +32,7 @@ from zigzag.cost_model.cost_model import CostModelEvaluation
 from zigzag.datatypes import LayerDim, UnrollFactorInt
 from zigzag.hardware.architecture.accelerator import Accelerator
 from zigzag.mapping.spatial_mapping_internal import SpatialMappingInternal
+from zigzag.mapping.temporal_mapping import TemporalMappingType
 from zigzag.opt.loma.memory_allocator import MemoryAllocator
 from zigzag.workload.layer_node import LayerNode
 
@@ -46,6 +47,7 @@ class SalsaState:
         spatial_mapping: SpatialMappingInternal,
         ordering: list[tuple[LayerDim, UnrollFactorInt]],
         opt_criterion_name: str,
+        mapping_type: TemporalMappingType,
     ):
         assert opt_criterion_name in ("energy", "latency")  # TODO make this an enum?
         self.ordering = ordering
@@ -54,8 +56,9 @@ class SalsaState:
         self.spatial_mapping = spatial_mapping
         self.memory_hierarchy = self.accelerator.memory_hierarchy
         self.opt_criterion_name = opt_criterion_name
+        self.mapping_type = mapping_type
 
-        allocator = MemoryAllocator(self.accelerator, self.layer, self.spatial_mapping, ordering)
+        allocator = MemoryAllocator(self.accelerator, self.layer, self.spatial_mapping, ordering, self.mapping_type)
 
         self.temporal_mapping = allocator.run()  # allocate this ordering to the memories
 
@@ -87,4 +90,5 @@ class SalsaState:
             self.spatial_mapping,
             swapped_ordering,
             self.opt_criterion_name,
+            self.mapping_type,
         )

--- a/zigzag/stages/mapping/salsa.py
+++ b/zigzag/stages/mapping/salsa.py
@@ -33,6 +33,7 @@ import multiprocessing_on_dill as multiprocessing  # type: ignore
 from zigzag.cost_model.cost_model import CostModelEvaluation
 from zigzag.hardware.architecture.accelerator import Accelerator
 from zigzag.mapping.spatial_mapping_internal import SpatialMappingInternal
+from zigzag.mapping.temporal_mapping import TemporalMappingType
 from zigzag.opt.salsa.engine import SalsaEngine
 from zigzag.stages.stage import Stage, StageCallable
 from zigzag.workload.layer_node import LayerNode
@@ -52,6 +53,7 @@ class SalsaStage(Stage):
         accelerator: Accelerator,
         layer: LayerNode,
         spatial_mapping: SpatialMappingInternal,
+        temporal_mapping_type: TemporalMappingType,
         **kwargs: Any,
     ):
         """
@@ -64,6 +66,7 @@ class SalsaStage(Stage):
             layer,
             spatial_mapping,
         )
+        self.mapping_type = temporal_mapping_type
         self.engine = None
         self.best_cme: CostModelEvaluation | None = None
 
@@ -89,6 +92,7 @@ class SalsaStage(Stage):
             accelerator=self.accelerator,
             layer=self.layer,
             spatial_mapping=self.spatial_mapping,
+            mapping_type=self.mapping_type,
             **self.kwargs,
         )
 


### PR DESCRIPTION
This PR adds an 'even' or 'uneven' mapping type.
This is used in Loma/Salsa's MemoryAllocator to make sure the allocated loops are even or uneven.

The api call is updated to enable choice between these two by passing in the 'even' or 'uneven' string.