### PR TITLE
Update gemm accelerators to new port definition

### DIFF
--- a/tests/main/test_origin/test_gemm_l1.py
+++ b/tests/main/test_origin/test_gemm_l1.py
@@ -6,7 +6,7 @@ workloads = ("zigzag/inputs/workload/gemm_layer.yaml",)
 
 # Expected energy and latency for each workload defined above
 ens_lats = {
-    "zigzag/inputs/workload/gemm_layer.yaml": (144927.36, 4.097e3),
+    "zigzag/inputs/workload/gemm_layer.yaml": (511349.76000000007, 8191.0),
 }
 
 

--- a/tests/main/test_origin/test_gemm_l1_l3.py
+++ b/tests/main/test_origin/test_gemm_l1_l3.py
@@ -6,7 +6,7 @@ workloads = ("zigzag/inputs/workload/gemm_layer.yaml",)
 
 # Expected energy and latency for each workload defined above
 ens_lats = {
-    "zigzag/inputs/workload/gemm_layer.yaml": (858452.48, 4.162e3),
+    "zigzag/inputs/workload/gemm_layer.yaml": (1111828.48, 8194),
 }
 
 

--- a/zigzag/inputs/hardware/gemm_l1.yaml
+++ b/zigzag/inputs/hardware/gemm_l1.yaml
@@ -3,43 +3,66 @@ name: gemm_l1
 memories:
   reg_O:
     size: 32
-    r_bw: 32
-    w_bw: 32
     r_cost: 0.02  # TODO
     w_cost: 0.02  # TODO
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     auto_cost_extraction: False
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: w_port_1
+        type: write
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, fh
+      - name: r_port_1
+        type: read
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, tl
+      - name: w_port_2
+        type: write
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, fl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, th
     served_dimensions: [D2]
 
   l1:
     size: 4194304
-    r_bw: 2048
-    w_bw: 2048
     r_cost: 22.9  # TODO
     w_cost: 52.01 # TODO
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 3
     latency: 1
     operands: [I1, I2, O]
-    min_r_granularity: 64
-    min_w_granularity: 64
     ports:
-      - tl: rw_port_1
-      - tl: rw_port_2
-      - tl: rw_port_3
-        fl: rw_port_3
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I1, tl
+      - name: rw_port_2
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I2, tl
+      - name: rw_port_3
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - O, tl
+          - O, fl
     served_dimensions: [D1, D2, D3]
 
 operational_array:

--- a/zigzag/inputs/hardware/gemm_l1.yaml
+++ b/zigzag/inputs/hardware/gemm_l1.yaml
@@ -47,13 +47,13 @@ memories:
       - name: rw_port_1
         type: read_write
         bandwidth_min: 64
-        bandwidth_max: 2048
+        bandwidth_max: 512
         allocation: 
           - I1, tl
       - name: rw_port_2
         type: read_write
         bandwidth_min: 64
-        bandwidth_max: 2048
+        bandwidth_max: 512
         allocation: 
           - I2, tl
       - name: rw_port_3

--- a/zigzag/inputs/hardware/gemm_l1_l3.yaml
+++ b/zigzag/inputs/hardware/gemm_l1_l3.yaml
@@ -3,70 +3,98 @@ name: gemm_l1_l3
 memories:
   reg_O:
     size: 32
-    r_bw: 32
-    w_bw: 32
     r_cost: 0.02  # TODO
     w_cost: 0.02  # TODO
     area: 0
-    r_port: 2
-    w_port: 2
-    rw_port: 0
     latency: 1
     auto_cost_extraction: False
     operands: [O]
     ports:
-      - fh: w_port_1
-        tl: r_port_1
-        fl: w_port_2
-        th: r_port_2
+      - name: r_port_1
+        type: read
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, tl
+      - name: r_port_2
+        type: read
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, th
+      - name: w_port_1
+        type: write
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, fh
+      - name: w_port_2
+        type: write
+        bandwidth_min: 32
+        bandwidth_max: 32
+        allocation: 
+          - O, fl
     served_dimensions: [D2]
 
   l1:
     size: 943718 # 128 kiB - 10% for the snitch stack
-    r_bw: 2048
-    w_bw: 2048
     r_cost: 22.9  # TODO
     w_cost: 52.01 # TODO
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 4
     latency: 1
     operands: [I1, I2, O]
-    min_r_granularity: 64
-    min_w_granularity: 64
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_2
-        tl: rw_port_2
-      - fh: rw_port_3
-        tl: rw_port_3
-        fl: rw_port_4
-        th: rw_port_4
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I1, fh
+          - I1, tl
+      - name: rw_port_2
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - I2, fh
+          - I2, tl
+      - name: rw_port_3
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - O, fh
+          - O, tl
+      - name: rw_port_4
+        type: read_write
+        bandwidth_min: 64
+        bandwidth_max: 2048
+        allocation: 
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2, D3]
 
   l3:
     size: 10000000000
-    r_bw: 512
-    w_bw: 512
     r_cost: 700  # TODO
     w_cost: 750  # TODO
     area: 0
-    r_port: 0
-    w_port: 0
-    rw_port: 1
     latency: 1
     operands: [I1, I2, O]
     ports:
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-      - fh: rw_port_1
-        tl: rw_port_1
-        fl: rw_port_1
-        th: rw_port_1
+      - name: rw_port_1
+        type: read_write
+        bandwidth_min: 512
+        bandwidth_max: 512
+        allocation: 
+          - I1, fh
+          - I1, tl
+          - I2, fh
+          - I2, tl
+          - O, fh
+          - O, tl
+          - O, fl
+          - O, th
     served_dimensions: [D1, D2, D3]
 
 operational_array:

--- a/zigzag/inputs/hardware/gemm_l1_l3.yaml
+++ b/zigzag/inputs/hardware/gemm_l1_l3.yaml
@@ -47,30 +47,30 @@ memories:
       - name: rw_port_1
         type: read_write
         bandwidth_min: 64
-        bandwidth_max: 2048
+        bandwidth_max: 512
         allocation: 
-          - I1, fh
           - I1, tl
       - name: rw_port_2
         type: read_write
         bandwidth_min: 64
-        bandwidth_max: 2048
+        bandwidth_max: 512
         allocation: 
-          - I2, fh
           - I2, tl
       - name: rw_port_3
         type: read_write
         bandwidth_min: 64
         bandwidth_max: 2048
         allocation: 
-          - O, fh
           - O, tl
-      - name: rw_port_4
+          - O, fl
+      - name: rw_port_4  # DMA port
         type: read_write
         bandwidth_min: 64
-        bandwidth_max: 2048
+        bandwidth_max: 512
         allocation: 
-          - O, fl
+          - I1, fh
+          - I2, fh
+          - O, fh
           - O, th
     served_dimensions: [D1, D2, D3]
 

--- a/zigzag/inputs/mapping/gemm_l1.yaml
+++ b/zigzag/inputs/mapping/gemm_l1.yaml
@@ -3,9 +3,9 @@
     D1:
       - D0, 8
     D2:
-      - D1, 8
-    D3:
       - D2, 8
+    D3:
+      - D1, 8
   temporal_ordering:
     - [D1, "*"]
     - [D2, "*"]

--- a/zigzag/inputs/mapping/gemm_l1_l3.yaml
+++ b/zigzag/inputs/mapping/gemm_l1_l3.yaml
@@ -3,16 +3,13 @@
     D1:
       - D0, 8
     D2:
-      - D1, 8
-    D3:
       - D2, 8
+    D3:
+      - D1, 8
   temporal_ordering:
     - [D1, "*"]
     - [D2, "*"]
     - [D0, "*"]
-    - [D1, 8]
-    - [D2, 8]
-    - [D0, 8]
   memory_operand_links:
     O: O
     W: I2

--- a/zigzag/inputs/workload/gemm_layer.yaml
+++ b/zigzag/inputs/workload/gemm_layer.yaml
@@ -1,6 +1,6 @@
 - id: 0
   operator_type: Gemm
-  equation: O[d0][d2]+=I[d0][d1]*W[d1][d2]
+  equation: O[d0][d1]+=I[d0][d2]*W[d2][d1]
   dimension_relations: []
   loop_dims: [D0, D1, D2]
   loop_sizes: [128, 128, 128]


### PR DESCRIPTION
Brings gemm accelerators `gemm_l1.yaml` and `gemm_l1_l3.yaml` up to the new definition of MemoryPorts. 

TODO: Differentiate bandwidths between ports. @jorendumoulin I could use your help for this.