### PR TITLE
Update layer_node.py

### DIFF
--- a/zigzag/workload/layer_node.py
+++ b/zigzag/workload/layer_node.py
@@ -205,16 +205,20 @@ class LayerNode(LayerNodeABC):
             # None constant: take the second one
             act_layer_op = self.input_operands[1]
         else:
-            pr_loop_key = next(iter(self.pr_loop.keys()))
-            related_loop_dict: dict[LayerOperand, list[LayerDim]] = {
-                layer_op: self.equation.get_r_layer_dims(layer_op)
-                for layer_op in self.equation.get_contained_operands()
-            }
-            act_layer_op = [
-                operand_in_layer
-                for operand_in_layer, related_loop in related_loop_dict.items()
-                if pr_loop_key in related_loop
-            ].pop()
+            # Check if the pr_loop is empty (first gemm layer)
+            if len(self.pr_loop) == 0:
+                act_layer_op = self.input_operands[0] # first operand is I by default
+            else:
+                pr_loop_key = next(iter(self.pr_loop.keys()))
+                related_loop_dict: dict[LayerOperand, list[LayerDim]] = {
+                    layer_op: self.equation.get_r_layer_dims(layer_op)
+                    for layer_op in self.equation.get_contained_operands()
+                }
+                act_layer_op = [
+                    operand_in_layer
+                    for operand_in_layer, related_loop in related_loop_dict.items()
+                    if pr_loop_key in related_loop
+                ].pop()
         return act_layer_op
 
     def get_weight_layer_op(

--- a/zigzag/workload/layer_node.py
+++ b/zigzag/workload/layer_node.py
@@ -207,7 +207,7 @@ class LayerNode(LayerNodeABC):
         else:
             # Check if the pr_loop is empty (first gemm layer)
             if len(self.pr_loop) == 0:
-                act_layer_op = self.input_operands[0] # first operand is I by default
+                act_layer_op = self.input_operands[0]  # first operand is I by default
             else:
                 pr_loop_key = next(iter(self.pr_loop.keys()))
                 related_loop_dict: dict[LayerOperand, list[LayerDim]] = {


### PR DESCRIPTION
Fix to avoid `RuntimeError: generator raised StopIteration (at ...temporal_mapping_generator_stage.py:48). `when running IMC architectures with GEMM. Since there are no partially relevant loops (`next(iter(self.pr_loop.keys()))` is null) for GEMMs, there is a need to add this case to decide activation layer operand. Note that this is not a problem for digital arithmetic because the `cost_model `does not care which operand is activation. But for IMC architectures, the cost model stage requires `layer_act_operand` to get the mapping and calculate the mac energy.